### PR TITLE
Now let in core creates only single binding

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
@@ -5,7 +5,6 @@ module Hschain.Utxo.Lang.Compile(
   , toCoreScript
 ) where
 
-import Control.Arrow (first)
 import Control.Monad
 
 import Data.Fix
@@ -69,7 +68,10 @@ toCoreProg = fmap CoreProg . mapM toScomb . unAnnLamProg
           EVar loc name        -> specifyPolyFun loc typeCtx exprTy name
           EPrim _ prim         -> pure $ Core.EPrim $ primLoc'value prim
           EAp _  f a           -> pure $ Core.EAp f a
-          ELet _ binds e       -> pure $ Core.ELet (first typed'value <$> binds) e
+          -- FIXME: We don't take recurion between let bindings into account
+          ELet _ binds body    -> pure $
+            let addLet (nm, e) = Core.ELet (typed'value nm) e
+            in foldr addLet body binds
           ELam _ _ _           -> eliminateLamError
           EIf _ c t e          -> pure $ Core.EIf c t e
           ECase _ e alts       -> pure $ Core.ECase e (fmap convertAlt alts)
@@ -108,4 +110,3 @@ specifyPolyFun loc ctx ty name = do
       case mapM (H.applyToVar subst) argOrder of
         Just ts -> return $ Core.EPolyVar name ts
         Nothing -> failedToFindMonoType loc name
-

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
@@ -60,7 +60,7 @@ data ExprCore
   -- ^ constant primitive
   | EAp  ExprCore ExprCore
   -- ^ application
-  | ELet [(Name, ExprCore)] ExprCore
+  | ELet Name ExprCore ExprCore
   -- ^ lent bindings
   | EIf ExprCore ExprCore ExprCore
   -- ^ if expressions

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Primitives.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Primitives.hs
@@ -443,7 +443,7 @@ filterComb = Scomb
       (ECase "as"
         [ CaseAlt 0 [] (EConstr nilT 0 0)
         , CaseAlt 1 [x, xs]
-            (ELet [("ys", ap "filter" ["f", "xs"])]
+            (ELet "ys" (ap "filter" ["f", "xs"])
                   (EIf (EAp "f" "x")
                        (ap (EConstr consT 1 2) ["x", "ys"])
                        "ys"

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/RecursionCheck.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/RecursionCheck.hs
@@ -9,7 +9,6 @@ import Hschain.Utxo.Lang.Core.Compile.Expr
 import Hschain.Utxo.Lang.Core.Data.Prim
 
 import qualified Data.Graph as G
-import qualified Data.List  as L
 import qualified Data.Set   as S
 
 -- | Check that program has no recursion
@@ -39,7 +38,7 @@ freeVars = \case
   EPolyVar name _ -> fromVar name
   EPrim _         -> S.empty
   EAp f a         -> freeVars f <> freeVars a
-  ELet binds e    -> freeLetVars binds e
+  ELet nm e body  -> freeLetVars nm e body
   EIf a b c       -> freeVars a <> freeVars b <> freeVars c
   ECase e alts    -> freeVars e <> foldMap freeAltVars alts
   EConstr _ _ _   -> S.empty
@@ -48,17 +47,8 @@ freeVars = \case
     fromVar name = S.singleton name
     freeAltVars CaseAlt{..} =
       freeVars caseAlt'rhs S.\\ (S.fromList $ fmap typed'value caseAlt'args)
+    freeLetVars nm e body = S.delete nm (freeVars e <> freeVars body)
 
-    freeLetVars binds e = eVars <> bindVars
-      where
-        eVars = freeVars e S.\\ bindNames
-
-        bindNames = S.fromList $ fmap fst binds
-
-        bindVars = fst $ L.foldl' go (mempty, mempty) binds
-          where
-            go (res, binded) (name, expr) =
-              ((res <> freeVars expr) S.\\ binded, S.insert name binded)
 
 -- | Build dependencies for a single supercmbinator
 scombToDep :: Scomb -> Dep
@@ -71,22 +61,14 @@ checkLets = checkLetExpr . typed'value . scomb'body
 -- | Check all subexpressions that let'bindings are acyclic.
 checkLetExpr :: ExprCore -> Bool
 checkLetExpr = \case
-  EAp f a       -> checkLetExpr f && checkLetExpr a
-  ELet binds e  -> checkBinds binds e
-  EIf a b c     -> checkLetExpr a && checkLetExpr b && checkLetExpr c
-  ECase e alts  -> checkLetExpr e && all checkAlts alts
-  EVar _        -> checkVar
-  EPolyVar _ _  -> checkVar
-  EConstr _ _ _ -> True
-  EPrim _       -> True
-  EBottom       -> True
-  where
-    checkVar = True
+  EAp f a        -> checkLetExpr f && checkLetExpr a
+  ELet nm e body -> nm `S.notMember` freeVars e && checkLetExpr body
+  EIf a b c      -> checkLetExpr a && checkLetExpr b && checkLetExpr c
+  ECase e alts   -> checkLetExpr e && all (checkLetExpr . caseAlt'rhs) alts
+  EVar _         -> True
+  EPolyVar _ _   -> True
+  EConstr _ _ _  -> True
+  EPrim _        -> True
+  EBottom        -> True
 
-    checkBinds binds e = checkLetExpr e && all (checkLetExpr . snd) binds && check binds
-      where
-        check bs = depIsAcyclic $ fmap (\b -> (fst b, S.toList $ freeVars $ snd b)) bs
-
-    checkAlts CaseAlt{..} = checkLetExpr caseAlt'rhs
-
-
+  

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
@@ -112,9 +112,8 @@ evalExpr genv = recur
         _                 -> ValBottom TypeMismatch
       -- FIXME: Here we assume that let is completely nonrecursive
       --        (For simplicity)
-      ELet binds body ->
-        let lenv' = MapL.fromList [ (nm, recur lenv' e) | (nm,e) <- binds ]
-                 <> lenv
+      ELet nm bind body ->
+        let lenv' = MapL.insert nm (recur lenv bind) lenv
         in recur lenv' body
       --
       ECase e alts -> case recur lenv e of


### PR DESCRIPTION
This removes all ambguity related to the recursion and scoping in the let block
with multiple bindings

This introduces mismatch in compilation to core. Surafce language has let with
multiple bindings. We translate blindly without regard to scoping so it may lead
to surprises