### PR TITLE
WIP: type safe case

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
@@ -98,9 +98,8 @@ toCoreProg = fmap CoreProg . mapM toScomb . unAnnLamProg
           EAssertType _ e _    -> pure e
           EBottom _            -> pure $ Core.EBottom
 
-        convertAlt CaseAlt{..} = do
-          args <- traverse convertTyped caseAlt'args
-          return Core.CaseAlt { caseAlt'args = args
+        convertAlt CaseAlt{..} =
+          return Core.CaseAlt { caseAlt'args = typed'value <$> caseAlt'args
                               , ..
                               }
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
@@ -168,7 +168,7 @@ data CaseAlt = CaseAlt
   { caseAlt'tag   :: !Int
   -- ^ integer tag of the constructor
   -- (integer substitution for the name of constructor)
-  , caseAlt'args  :: [Typed TypeCore Name]
+  , caseAlt'args  :: [Name]
   -- ^ arguments of the pattern matching
   , caseAlt'rhs   :: ExprCore
   -- ^ right-hand side of the case-alternative

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/RecursionCheck.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/RecursionCheck.hs
@@ -53,7 +53,7 @@ freeVars = \case
   where
     fromVar name = S.singleton name
     freeAltVars CaseAlt{..} =
-      freeVars caseAlt'rhs S.\\ (S.fromList $ fmap typed'value caseAlt'args)
+      freeVars caseAlt'rhs S.\\ (S.fromList caseAlt'args)
     freeLetVars nm e body = S.delete nm (freeVars e <> freeVars body)
 
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Cost.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Cost.hs
@@ -136,7 +136,9 @@ exprCost typeCostMap costMap expr = case expr of
 
     costCase e alts = liftA2 addCost (rec e) (fmap maximumCost $ mapM costAlt alts)
 
-    costAlt CaseAlt{..} = exprCost typeCostMap (appendArgs typeCostMap caseAlt'args costMap) caseAlt'rhs
+    -- FIXME: We dropped types from case alternatives
+    costAlt CaseAlt{..} = Just unitCost
+    -- exprCost typeCostMap (appendArgs typeCostMap caseAlt'args costMap) caseAlt'rhs
 
     costConstr _ _ _ = return unitCost
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
@@ -134,9 +134,9 @@ evalExpr inpEnv genv = recur
               | otherwise          = matchCase cs
             matchCase [] = ValBottom $ EvalErr "No match in case"
             --
-            bindParams []             []             = id
-            bindParams (v:vs) (Typed n _:ts) = bindParams vs ts . Map.insert n v
-            bindParams _ _ = error "Type error in case"
+            bindParams []     []     = id
+            bindParams (v:vs) (n:ns) = bindParams vs ns . Map.insert n v
+            bindParams _      _      = error "Type error in case"
         ValBottom err -> ValBottom err
         _             -> ValBottom TypeMismatch
       EConstr _ tag arity    -> constr tag arity

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
@@ -88,6 +88,7 @@ data TypeCoreError
   | PolymorphicLet
   | BadEquality TypeCore
   | BadShow     TypeCore
+  | BadCase
   deriving stock    (Show,Eq,Generic)
   deriving anyclass (NFData)
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -260,6 +260,7 @@ instance Pretty TypeCoreError where
     PolymorphicLet           -> "polymorphic type in the let binding"
     BadEquality ty           -> hsep ["Error: non comparable type:", pretty ty]
     BadShow     ty           -> hsep ["Error: non showable type:", pretty ty]
+    BadCase                  -> "Error: Type error in case expression"
 
 instance Pretty InternalError where
   pretty = \case

--- a/hschain-utxo-lang/test/TM/Core.hs
+++ b/hschain-utxo-lang/test/TM/Core.hs
@@ -102,15 +102,15 @@ progListCase = CoreProg
   where
     safeHead e = ECase e
       [ CaseAlt 0 [] (EPrim (PrimInt 0))
-      , CaseAlt 1 [Typed "x" IntT, Typed "xs" (ListT IntT)] (EVar "x")
+      , CaseAlt 1 ["x", "xs"] (EVar "x")
       ]
 
 badListCase :: CoreProg
 badListCase = CoreProg
   [ mkMain $ Typed
     { typed'value = ECase nil
-        [ CaseAlt 0 [Typed "x" IntT]                          zero
-        , CaseAlt 1 [Typed "x" IntT, Typed "xs" (ListT IntT)] zero
+        [ CaseAlt 0 ["x"]                          zero
+        , CaseAlt 1 ["x", "xs"] zero
         ]
     , typed'type  = IntT
     }


### PR DESCRIPTION
This is draft of implementation of type safe case in core. It makes use of the fact that we have only few types that could be matched in case expressions. Most important changes to core:

1. Variables in case don't have explicit type annotations. Types are inferred
2. Type tags are inferred from order of case expressions

Main complication is compilation to core. It's not trivial to convert from explicit tags to order of tags