### PR TITLE
Drop Box constructor.

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
@@ -78,7 +78,6 @@ data PrimOp a
   | OpGetBoxScript
   | OpGetBoxValue
   | OpGetBoxArgs !ArgType -- ^ Get arguments from box
-  | OpMakeBox
 
   | OpListMap    !a !a    -- ^ Map over list
   | OpListAt     !a       -- ^ Index list

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
@@ -222,7 +222,6 @@ primopToType = \case
   OpGetBoxScript -> pure $ BoxT :-> BytesT
   OpGetBoxValue  -> pure $ BoxT :-> IntT
   OpGetBoxArgs t -> pure $ BoxT :-> ListT (tagToType t)
-  OpMakeBox      -> pure $ BytesT :-> BytesT :-> IntT :-> argsTuple :-> BoxT
   --
   OpShow      ty  -> showType ty
   OpToBytes   tag -> pure $ tagToType tag :-> BytesT

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
@@ -227,7 +227,6 @@ evalPrimOp env = \case
       BoolArg  -> bools
       BytesArg -> bytes
     p -> ValBottom $ EvalErr $ "Not a box. Got " ++ show p
-  OpMakeBox -> Val2F $ \a b -> Val2F $ \c d -> ValCon 0 [a,b,c,d]
   --
   OpEnvGetHeight -> ValP $ PrimInt $ inputEnv'height env
   OpEnvGetSelf   -> inj $ inputEnv'self env

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -888,7 +888,6 @@ monoPrimopName = \case
   OpGetBoxScript -> Just Const.getBoxScript
   OpGetBoxValue  -> Just Const.getBoxValue
   OpGetBoxArgs t -> Just $ Const.getBoxArgs $ argTypeName t
-  OpMakeBox      -> Just "Box"
   --
   OpEnvGetHeight  -> Just "getHeight"
   OpEnvGetSelf    -> Just "getSelf"
@@ -924,7 +923,7 @@ monomorphicPrimops =
   , OpSigAnd, OpSigOr, OpSigPK, OpSigBool, OpSigListAnd, OpSigListOr
   , OpSHA256, OpTextLength, OpBytesLength, OpTextAppend, OpBytesAppend
   , OpEnvGetHeight, OpEnvGetSelf, OpEnvGetInputs, OpEnvGetOutputs
-  , OpGetBoxId, OpGetBoxScript, OpGetBoxValue, OpMakeBox
+  , OpGetBoxId, OpGetBoxScript, OpGetBoxValue
   , OpListSum
   , OpListAnd
   , OpListOr


### PR DESCRIPTION
Это явно архитектурная проблема. Я языке Box содержит  box ID, который нельзя посчитать, не имея полной транзакции. Отсюда следует, что нельзя просто взять и собрать Box в скрипте, т.к. взять box id неоткуда. Выходов из это ситуаци два:

1. Не давать способа создавать коробки в спенд-скриптах. Они могут только быть взяты из окружения
2. Убрать из коробки box ID и держать его отдельно

Неясно как изменение влияет на ЯВУ