### PR TITLE
Use machinery from hschain-crypto for Sigma expression

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -30,7 +30,6 @@ import qualified Type.Check.HM as HM(LocFunctor(..), Type)
 import qualified Hschain.Utxo.Lang.Parser.Hask.ToHask as H(toHaskType)
 import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
-import qualified Hschain.Utxo.Lang.Sigma.Types as Sig
 
 toName :: VarName -> H.Name Loc
 toName (VarName loc txt) = H.Ident loc $ T.unpack txt
@@ -59,7 +58,7 @@ toSigma loc = foldFix $ \case
 
     fromProofInput = \case
       Sigma.InputDLog   pk -> app loc "pk" [toText loc $ publicKeyToText pk]
-      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText . Sig.PublicKey)
+      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText)
         [ Sigma.dtuple'g    dt
         , Sigma.dtuple'g_x  dt
         , Sigma.dtuple'g_y  dt

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Crypto/Signature.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Crypto/Signature.hs
@@ -16,8 +16,7 @@ import GHC.Generics
 import HSChain.Crypto (ByteRepr(..),CryptoAsymmetric(..))
 import HSChain.Crypto.Classes.Hash
 import Hschain.Utxo.Lang.Sigma (CryptoAlg, PublicKey, Secret, SigMessage)
-import Hschain.Utxo.Lang.Sigma.EllipticCurve (EC(..), ECPoint, hashDomain)
-import Hschain.Utxo.Lang.Sigma.Types (Response)
+import Hschain.Utxo.Lang.Sigma.EllipticCurve (EC(..), ECPoint, Response, hashDomain)
 
 import qualified Data.ByteString as B
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Crypto/Signature.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Crypto/Signature.hs
@@ -13,7 +13,6 @@ import Control.DeepSeq
 
 import GHC.Generics
 
-
 import HSChain.Crypto (ByteRepr(..),CryptoAsymmetric(..))
 import HSChain.Crypto.Classes.Hash
 import Hschain.Utxo.Lang.Sigma (CryptoAlg, PublicKey, Secret, SigMessage)
@@ -21,8 +20,6 @@ import Hschain.Utxo.Lang.Sigma.EllipticCurve (EC(..), ECPoint, hashDomain)
 import Hschain.Utxo.Lang.Sigma.Types (Response)
 
 import qualified Data.ByteString as B
-
-import qualified Hschain.Utxo.Lang.Sigma.Types as Sigma
 
 -- | Signature.
 data Signature = Signature

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -176,9 +176,6 @@ instance Pretty S.ProofInput where
     Sigma.InputDTuple dt -> parens $ hsep $ punctuate comma $ fmap pretty
       [Sigma.dtuple'g dt, Sigma.dtuple'g_x dt, Sigma.dtuple'g_y dt, Sigma.dtuple'g_xy dt]
 
-instance Pretty S.PublicKey where
-  pretty = pretty . encodeBase58
-
 instance ByteRepr (EC.ECPoint a) => Pretty (EC.ECPoint a) where
   pretty = pretty . encodeBase58
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -76,6 +76,7 @@ import Text.Show.Deriving
 import HSChain.Crypto.Classes      (ViaBase58(..), ByteRepr(..))
 import HSChain.Crypto.Classes.Hash
 import HSChain.Crypto.SHA          (SHA256)
+import qualified HSChain.Crypto as Crypto
 import qualified Hschain.Utxo.Lang.Sigma.Interpreter           as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.EllipticCurve         as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.MultiSig              as Sigma
@@ -92,10 +93,10 @@ type CryptoAlg = Sigma.Ed25519
 type KeyPair    = Sigma.KeyPair    CryptoAlg
 
 -- | Public key.
-type PublicKey  = Sigma.PublicKey  CryptoAlg
+type PublicKey  = Crypto.PublicKey  CryptoAlg
 
 -- | Private key.
-type Secret     = Sigma.Secret     CryptoAlg
+type Secret     = Crypto.PrivKey    CryptoAlg
 
 -- | Environment to prove the ownership. It is a list of key-pairs
 -- that are owned by the prover.
@@ -120,11 +121,11 @@ instance Default SigMessage where
 
 -- | Generate new private key.
 newSecret :: IO Secret
-newSecret = Sigma.generateSecretKey
+newSecret = Crypto.generatePrivKey
 
 -- | Convert private key to public key.
 getPublicKey :: Secret -> PublicKey
-getPublicKey = Sigma.getPublicKey
+getPublicKey = Crypto.publicKey
 
 -- | Creates key-pair for given private key.
 getKeyPair :: Secret -> KeyPair
@@ -422,7 +423,7 @@ dlogInput :: PublicKey -> ProofInput
 dlogInput = Sigma.InputDLog
 
 dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
-dtupleInput genB (Sigma.PublicKey keyA) (Sigma.PublicKey keyB) =
+dtupleInput genB keyA keyB =
   Sigma.InputDTuple $ Sigma.DTuple Sigma.groupGenerator genB keyA keyB
 
 $(deriveShow1 ''SigmaF)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -13,6 +13,7 @@ module Hschain.Utxo.Lang.Sigma.DLog(
 
 import GHC.Generics (Generic)
 
+import HSChain.Crypto
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Types
 
@@ -53,7 +54,7 @@ instance ( CBOR.Serialise (ECPoint   a)
 -- challenge
 simulateProofDLog :: EC a => PublicKey a -> Challenge a -> IO (ProofDLog a)
 simulateProofDLog pubK e = do
-  z <- generateScalar
+  z <- generatePrivKey
   return ProofDLog
     { proofDLog'public      = pubK
     , proofDLog'commitmentA = getCommitment z e pubK
@@ -63,5 +64,6 @@ simulateProofDLog pubK e = do
 
 verifyProofDLog :: (EC a) => ProofDLog a -> Bool
 verifyProofDLog ProofDLog{..}
-  = fromGenerator proofDLog'responseZ == (proofDLog'commitmentA ^+^ (fromChallenge proofDLog'challengeE .*^ unPublicKey proofDLog'public))
+  =  publicKey proofDLog'responseZ
+  == (proofDLog'commitmentA ^+^ (fromChallenge proofDLog'challengeE .*^ proofDLog'public))
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -40,7 +40,8 @@ import Data.Either.Extra (eitherToMaybe)
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import GHC.Generics (Generic)
 
-import HSChain.Crypto.Classes (ByteRepr(..), defaultToJSON, defaultParseJSON)
+import HSChain.Crypto
+import HSChain.Crypto.Classes (defaultToJSON, defaultParseJSON)
 import HSChain.Crypto.Classes.Hash
 
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
@@ -84,15 +85,15 @@ verifyProofDTuple ProofDTuple{..}
 
 getCommitmentDTuple :: EC a => Response a -> Challenge a -> DTuple a -> (Commitment a, Commitment a)
 getCommitmentDTuple z ch DTuple{..} =
-  ( getCommitment z ch (PublicKey dtuple'g_y)
-  , getCommitment z ch (PublicKey dtuple'g_xy)
+  ( getCommitment z ch dtuple'g_y
+  , getCommitment z ch dtuple'g_xy
   )
 
 -- | Simulate proof of posession of discrete logarithm for given
 -- challenge
 simulateProofDTuple :: EC a => DTuple a -> Challenge a -> IO (ProofDTuple a)
 simulateProofDTuple dt e = do
-  z <- generateScalar
+  z <- generatePrivKey
   return ProofDTuple
     { proofDTuple'public      = dt
     , proofDTuple'commitmentA = getCommitmentDTuple z e dt

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -4,6 +4,8 @@ module Hschain.Utxo.Lang.Sigma.EllipticCurve(
   , Ed25519
   , ECPoint
   , ECScalar
+  , Commitment
+  , Response
   , hashDomain
   ) where
 
@@ -35,8 +37,10 @@ import HSChain.Crypto.Classes.Hash
 infixl 6 .+.
 infixl 7 .*.
 
-type ECPoint  = PublicKey
-type ECScalar = PrivKey
+type ECPoint    = PublicKey
+type ECScalar   = PrivKey
+type Commitment = ECPoint
+type Response   = ECScalar
 
 -- | Operations with elliptic curve
 class ( CryptoAsymmetric a 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -34,7 +34,6 @@ class ( ByteRepr (ECPoint   a)
       , ByteRepr (Challenge a)
       , Eq (ECScalar a)
       , Eq (Challenge a)
-      , Ord (ECPoint a)
       ) => EC a where
   data ECPoint   a
   data ECScalar  a

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -11,6 +11,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad.IO.Class
 import Crypto.Error
 import Data.Aeson (FromJSON(..),ToJSON(..),FromJSONKey(..),ToJSONKey(..))
+import Data.Data
 import Data.Bits
 import Data.Coerce
 import Data.Function (on)
@@ -25,13 +26,16 @@ import qualified Crypto.Hash              as Hash
 import qualified Crypto.Random.Types      as RND
 import qualified Data.ByteArray           as BA
 import qualified Data.ByteString          as BS
+import qualified Language.Haskell.TH.Syntax as TH
+import Instances.TH.Lift ()
 import HSChain.Crypto
 import HSChain.Crypto.Classes.Hash
+
 
 infixl 6 .+.
 infixl 7 .*.
 
-type ECPoint = PublicKey
+type ECPoint  = PublicKey
 type ECScalar = PrivKey
 
 -- | Operations with elliptic curve
@@ -159,3 +163,14 @@ instance CryptoHashable (Challenge Ed25519) where
 
 hashDomain :: String
 hashDomain = "hschain.utxo.sigma"
+
+instance Data (PublicKey Ed25519) where
+  gfoldl _ _ _ = error       "PublicKey.gfoldl"
+  toConstr _   = error       "PublicKey.toConstr"
+  gunfold _ _  = error       "PublicKey.gunfold"
+  dataTypeOf _ = mkNoRepType "Hschain.Utxo.Lang.Sigma.Types.PublicKey"
+
+instance TH.Lift (PublicKey Ed25519) where
+  lift pk = [| let Just k = decodeFromBS bs in k |]
+    where
+      bs = encodeToBS pk

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -2,11 +2,13 @@
 module Hschain.Utxo.Lang.Sigma.EllipticCurve(
     EC(..)
   , Ed25519
+  , ECPoint
+  , ECScalar
   , hashDomain
   ) where
 
 import Control.DeepSeq (NFData)
-
+import Control.Monad.IO.Class
 import Crypto.Error
 import Data.Aeson (FromJSON(..),ToJSON(..),FromJSONKey(..),ToJSONKey(..))
 import Data.Bits
@@ -23,30 +25,28 @@ import qualified Crypto.Hash              as Hash
 import qualified Crypto.Random.Types      as RND
 import qualified Data.ByteArray           as BA
 import qualified Data.ByteString          as BS
+import HSChain.Crypto
 import HSChain.Crypto.Classes.Hash
 
 infixl 6 .+.
 infixl 7 .*.
 
+type ECPoint = PublicKey
+type ECScalar = PrivKey
+
 -- | Operations with elliptic curve
-class ( ByteRepr (ECPoint   a)
-      , ByteRepr (ECScalar  a)
+class ( CryptoAsymmetric a 
       , ByteRepr (Challenge a)
       , Eq (ECScalar a)
       , Eq (Challenge a)
       ) => EC a where
-  data ECPoint   a
-  data ECScalar  a
   data Challenge a
   -- Challenge part
   generateChallenge :: IO (Challenge a)
   randomOracle      :: BS.ByteString -> Challenge a
   xorChallenge      :: Challenge a -> Challenge a -> Challenge a
-
-  generateScalar    :: IO (ECScalar a)
   -- ^ generates random scalar
 
-  fromGenerator     :: ECScalar  a -> ECPoint  a
   -- ^ multiplies generator of the group N times (first argument)
 
   fromChallenge     :: Challenge a -> ECScalar a
@@ -62,30 +62,6 @@ class ( ByteRepr (ECPoint   a)
   (^+^)   :: ECPoint  a -> ECPoint  a -> ECPoint  a
   negateP :: ECPoint a -> ECPoint a
 
-instance ByteRepr (ECPoint a) => FromJSON (ECPoint a) where
-  parseJSON = defaultParseJSON "ECPoint"
-instance ByteRepr (ECPoint a) => ToJSON (ECPoint a) where
-  toJSON = defaultToJSON
-instance ByteRepr (ECPoint a) => FromJSONKey (ECPoint a) where
-  fromJSONKey = defaultFromJsonKey "ECPoint"
-instance ByteRepr (ECPoint a) => ToJSONKey   (ECPoint a) where
-  toJSONKey = defaultToJsonKey
-instance ByteRepr (ECPoint a) => CBOR.Serialise (ECPoint a) where
-  encode = defaultCborEncode
-  decode = defaultCborDecode "ECPoint"
-
-instance ByteRepr (ECScalar a) => FromJSON (ECScalar a) where
-  parseJSON = defaultParseJSON "ECScalar"
-instance ByteRepr (ECScalar a) => ToJSON (ECScalar a) where
-  toJSON = defaultToJSON
-instance ByteRepr (ECScalar a) => FromJSONKey (ECScalar a) where
-  fromJSONKey = defaultFromJsonKey "ECScalar"
-instance ByteRepr (ECScalar a) => ToJSONKey   (ECScalar a) where
-  toJSONKey = defaultToJsonKey
-instance ByteRepr (ECScalar a) => CBOR.Serialise (ECScalar a) where
-  encode = defaultCborEncode
-  decode = defaultCborDecode "ECScalar"
-
 instance ByteRepr (Challenge a) => FromJSON (Challenge a) where
   parseJSON = defaultParseJSON "Challenge"
 instance ByteRepr (Challenge a) => ToJSON (Challenge a) where
@@ -99,16 +75,27 @@ instance ByteRepr (Challenge a) => CBOR.Serialise (Challenge a) where
   decode = defaultCborDecode "Challenge"
 
 
+----------------------------------------------------------------
+-- Ed25519 elliptic curve
+----------------------------------------------------------------
+
 -- | Algorithm tag.
 data Ed25519
 
+newtype instance PublicKey Ed25519 = ECPoint25519  Ed.Point
+  deriving stock   (Eq,Generic)
+  deriving newtype (NFData)
+
+newtype instance PrivKey Ed25519 = ECScalar25519 Ed.Scalar
+  deriving stock   (Eq,Generic)
+  deriving newtype (NFData)
+
+instance CryptoAsymmetric Ed25519 where
+  generatePrivKey = liftIO $ coerce (Ed.scalarGenerate @IO)
+  publicKey = coerce Ed.toPoint
+  asymmKeyAlgorithmName = CryptoName "ECC.Ed25519"
+
 instance EC Ed25519 where
-  newtype ECPoint   Ed25519 = ECPoint25519  Ed.Point
-    deriving stock   (Show,Eq,Generic)
-    deriving newtype (NFData)
-  newtype ECScalar  Ed25519 = ECScalar25519 Ed.Scalar
-    deriving stock   (Show,Eq,Generic)
-    deriving newtype (NFData)
   newtype Challenge Ed25519 = ChallengeEd25519 BS.ByteString
     deriving stock   (Show,Eq,Ord,Generic)
     deriving newtype (NFData)
@@ -123,8 +110,6 @@ instance EC Ed25519 where
     $ BS.pack
     $ BS.zipWith xor a b
 
-  generateScalar    = coerce (Ed.scalarGenerate @IO)
-  fromGenerator     = coerce Ed.toPoint
   -- FIXME: We need to maintain that challenge is less than group
   --        module, right?
   fromChallenge (ChallengeEd25519 bs) =
@@ -151,11 +136,18 @@ instance ByteRepr (ECPoint Ed25519) where
     CryptoFailed _ -> Nothing
   encodeToBS (ECPoint25519 p) = Ed.pointEncode p
 
+instance ByteReprSized (ECPoint Ed25519) where
+  type ByteSize (ECPoint Ed25519) = 32
+
 instance ByteRepr (ECScalar Ed25519) where
   decodeFromBS bs = case Ed.scalarDecodeLong bs of
     CryptoPassed p -> Just $ ECScalar25519 p
     CryptoFailed _ -> Nothing
   encodeToBS (ECScalar25519 p) = Ed.scalarEncode p
+
+instance ByteReprSized (ECScalar Ed25519) where
+  -- FIXME: Questionable
+  type ByteSize (ECScalar Ed25519) = 32
 
 instance ByteRepr (Challenge Ed25519) where
   decodeFromBS = Just . ChallengeEd25519
@@ -163,16 +155,6 @@ instance ByteRepr (Challenge Ed25519) where
 
 instance CryptoHashable (Challenge Ed25519) where
   hashStep = genericHashStep hashDomain
-
-instance CryptoHashable (ECScalar Ed25519) where
-  hashStep x
-    =  hashStep (CryPrivateKey "Ed25519")
-    <> hashStep (encodeToBS x)
-
-instance CryptoHashable (ECPoint Ed25519) where
-  hashStep x
-    =  hashStep (CryPublicKey "Ed25519")
-    <> hashStep (encodeToBS x)
 
 
 hashDomain :: String

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
@@ -18,7 +18,6 @@ import GHC.Generics (Generic)
 import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Protocol
-import Hschain.Utxo.Lang.Sigma.Types
 import HSChain.Crypto
 
 import qualified Codec.Serialise          as CBOR

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
@@ -19,6 +19,7 @@ import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Protocol
 import Hschain.Utxo.Lang.Sigma.Types
+import HSChain.Crypto
 
 import qualified Codec.Serialise          as CBOR
 import qualified Data.ByteString.Lazy     as BL

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
@@ -85,7 +85,7 @@ import Data.Maybe
 import Data.Set (Set)
 import Data.Text (Text)
 
-import HSChain.Crypto (PublicKey,PrivKey,CryptoAsymmetric(..))
+import HSChain.Crypto (PublicKey,CryptoAsymmetric(..))
 import Hschain.Utxo.Lang.Sigma.DLog
 import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
@@ -85,12 +85,12 @@ import Data.Maybe
 import Data.Set (Set)
 import Data.Text (Text)
 
+import HSChain.Crypto (PublicKey,PrivKey,CryptoAsymmetric(..))
 import Hschain.Utxo.Lang.Sigma.DLog
 import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.FiatShamirTree
 import Hschain.Utxo.Lang.Sigma.Protocol
-import Hschain.Utxo.Lang.Sigma.Types
 import Hschain.Utxo.Lang.Sigma.Interpreter
 
 import qualified Data.List as L
@@ -206,11 +206,11 @@ queryCommitments knownKeys tree = fmap splitCommitmentAndSecret $ go tree
     go = \case
       -- if we own the key we generate randomness and commitment based on it
       Leaf tag (Left query) | ownsQuery knownKeys query -> do
-                        rnd <- liftIO generateScalar
+                        rnd <- generatePrivKey
                         return $ Leaf tag $ Left $
                           case query of
                             CommitmentQueryLog{..} -> CommitmentSecret
-                              { comSecret'query  = query { comQuery'commitmentLog = Just $ fromGenerator rnd }
+                              { comSecret'query  = query { comQuery'commitmentLog = Just $ publicKey rnd }
                               , comSecret'secret = Just rnd
                               }
                             CommitmentQueryTuple{..} -> CommitmentSecret

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
@@ -17,8 +17,9 @@ import Data.Aeson   (FromJSON(..), ToJSON(..))
 import Data.Either.Extra (eitherToMaybe)
 import GHC.Generics (Generic)
 
-import HSChain.Crypto.Classes (ByteRepr(..), defaultToJSON, defaultParseJSON)
+import HSChain.Crypto.Classes (defaultToJSON, defaultParseJSON)
 import HSChain.Crypto.Classes.Hash
+import HSChain.Crypto
 
 import Hschain.Utxo.Lang.Sigma.DLog
 import Hschain.Utxo.Lang.Sigma.DTuple

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
@@ -10,9 +10,6 @@ data KeyPair a = KeyPair
   , getPublicKey :: PublicKey a
   }
 
-type Commitment a = ECPoint a
-type Response a   = ECScalar a
-
 -- | Generate key-pair.
 generateKeyPair :: EC a => IO (KeyPair a)
 generateKeyPair = do

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
@@ -2,28 +2,7 @@
 module Hschain.Utxo.Lang.Sigma.Types where
 
 import HSChain.Crypto
-import qualified Language.Haskell.TH.Syntax as TH
-import Instances.TH.Lift ()
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
-
--- | Private key.
-newtype Secret a = Secret { unSecret :: ECScalar a }
-  deriving stock (Generic)
-
--- | Public key.
-newtype PublicKey a = PublicKey { unPublicKey :: ECPoint a }
-  deriving stock (Generic)
-
-instance Typeable a => Data (PublicKey a) where
-  gfoldl _ _ _ = error       "PublicKey.gfoldl"
-  toConstr _   = error       "PublicKey.toConstr"
-  gunfold _ _  = error       "PublicKey.gunfold"
-  dataTypeOf _ = mkNoRepType "Hschain.Utxo.Lang.Sigma.Types.PublicKey"
-
-instance ByteRepr (ECPoint a) => TH.Lift (PublicKey a) where
-  lift pk = [| let Just k = decodeFromBS bs in k |]
-    where
-      bs = encodeToBS pk
 
 -- | Pair of keys.
 data KeyPair a = KeyPair
@@ -33,25 +12,6 @@ data KeyPair a = KeyPair
 
 type Commitment a = ECPoint a
 type Response a   = ECScalar a
-
-deriving stock   instance Show (ECPoint a) => Show (PublicKey a)
-deriving stock   instance Eq   (ECPoint a) => Eq   (PublicKey a)
-deriving stock   instance Ord  (ECPoint a) => Ord  (PublicKey a)
-deriving newtype instance (CBOR.Serialise (ECScalar a)) => CBOR.Serialise (Secret a)
-deriving newtype instance (CBOR.Serialise (ECPoint a)) => CBOR.Serialise (PublicKey a)
-deriving newtype instance NFData (ECPoint a) => NFData (PublicKey a)
-deriving newtype instance (CryptoHashable (ECPoint a)) => CryptoHashable (PublicKey a)
-deriving newtype instance ByteRepr (ECPoint a) => ByteRepr (PublicKey a)
-deriving newtype instance (ByteRepr (ECPoint a)) => ToJSON (PublicKey a)
-deriving newtype instance (ByteRepr (ECPoint a)) => FromJSON (PublicKey a)
-
--- | Generate new private key.
-generateSecretKey :: EC a => IO (Secret a)
-generateSecretKey = coerce generateScalar
-
--- | Convert private key to public.
-getPublicKey :: EC a => Secret a -> PublicKey a
-getPublicKey = coerce fromGenerator
 
 -- | Generate key-pair.
 generateKeyPair :: EC a => IO (KeyPair a)

--- a/hschain-utxo-pow-node/test/TM/SmartCon/Basic.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/Basic.hs
@@ -31,7 +31,7 @@ tests = testGroup "Running blockchain"
 
 noDoubleTx :: Mine ()
 noDoubleTx = do
-  alice@KeyPair  {publicKey=pkAlice  } <- liftIO generateKeyPair
+  alice@KeyPair  {getPublicKey=pkAlice  } <- liftIO generateKeyPair
   let sigmaEnv = Sigma.Env [ alice ]
   -- H=1. Alice mines block
   bidAlice <- mineBlock (Just pkAlice) []
@@ -57,9 +57,9 @@ noDoubleTx = do
 
 simpleTransfers :: Mine ()
 simpleTransfers = do
-  alice@KeyPair  {publicKey=pkAlice  } <- liftIO generateKeyPair
-  bob@KeyPair    {publicKey=pkBob    } <- liftIO generateKeyPair
-  charlie@KeyPair{publicKey=pkCharlie} <- liftIO generateKeyPair
+  alice@KeyPair  {getPublicKey=pkAlice  } <- liftIO generateKeyPair
+  bob@KeyPair    {getPublicKey=pkBob    } <- liftIO generateKeyPair
+  charlie@KeyPair{getPublicKey=pkCharlie} <- liftIO generateKeyPair
   let sigmaEnv = Sigma.Env [ alice, bob, charlie ]
   ----------------------------------------
   -- H=1 Alice mines block

--- a/hschain-utxo-pow-node/test/TM/SmartCon/PayForCoffee.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/PayForCoffee.hs
@@ -26,8 +26,8 @@ tests = testGroup "Pay for coffee"
 
 payforCoffee :: Bool -> Mine ()
 payforCoffee isBob = do
-  alice@KeyPair{publicKey=pkAlice} <- liftIO $ generateKeyPair
-  bob@KeyPair  {publicKey=pkBob  } <- liftIO $ generateKeyPair
+  alice@KeyPair{getPublicKey=pkAlice} <- liftIO $ generateKeyPair
+  bob@KeyPair  {getPublicKey=pkBob  } <- liftIO $ generateKeyPair
   let sigmaEnv = Sigma.Env [ alice, bob ]
   -- H=1 Alice mines block
   bidAlice <- mineBlock (Just pkAlice) []

--- a/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
@@ -35,8 +35,8 @@ tests = testGroup "XorGame"
 
 xorGame :: Int64 -> Int64 -> Mine ()
 xorGame aliceGuess bobGuess = do
-  alice@KeyPair  {publicKey=pkAlice  } <- liftIO generateKeyPair
-  bob@KeyPair    {publicKey=pkBob    } <- liftIO generateKeyPair
+  alice@KeyPair  {getPublicKey=pkAlice  } <- liftIO generateKeyPair
+  bob@KeyPair    {getPublicKey=pkBob    } <- liftIO generateKeyPair
   let sigmaEnv = Sigma.Env [ alice, bob ]
   -- Alice and Bob mine some money
   bidAlice <- mineBlock (Just pkAlice) []


### PR DESCRIPTION
Основная идея это ПР — унификация API. Скаляр — это явным образом приватный ключ, точка на кривой — публичный. Не думаю, что слежует различать использование как точки и как ключа на уровне типов, т.к. это просто добавляет слоёв индирекции

Черновик в частности потому что требуются модификции в hschain. В частности выкинуть суперкласс ByteReprSized у CryptoAsymmetric и перенести туда KeyPair, последний тип данных выгляжит полезным в общем случае

Да и в целом, этот ПР следует подчистить