### PR TITLE
Use bytes instead of text to store public key

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Build.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Build.hs
@@ -59,11 +59,12 @@ import Data.Vector (Vector)
 import qualified Data.Text   as T
 import qualified Data.Vector as V
 
+import HSChain.Crypto (ByteRepr(..))
 import Hschain.Utxo.Lang.Compile
 import Hschain.Utxo.Lang.Desugar
 import Hschain.Utxo.Lang.Error
 import Hschain.Utxo.Lang.Pretty
-import Hschain.Utxo.Lang.Sigma (PublicKey, publicKeyToText)
+import Hschain.Utxo.Lang.Sigma (PublicKey)
 import Hschain.Utxo.Lang.Types
 import Hschain.Utxo.Lang.Expr
 
@@ -172,9 +173,9 @@ instance Boolean (Expr SigmaBool) where
   (||*) = sigmaOr
 
 pk' :: PublicKey -> Expr SigmaBool
-pk' = pk . text . publicKeyToText
+pk' = pk . bytes . encodeToBS
 
-pk :: Expr Text -> Expr SigmaBool
+pk :: Expr ByteString -> Expr SigmaBool
 pk (Expr key) = Expr $ Fix $ SigmaE noLoc $ Pk noLoc key
 
 sigmaAnd :: Expr SigmaBool -> Expr SigmaBool -> Expr SigmaBool

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Infer.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Infer.hs
@@ -17,7 +17,7 @@ import Hschain.Utxo.Lang.Compile.Expr
 import Hschain.Utxo.Lang.Core.Types             (Name, Typed(..))
 import Hschain.Utxo.Lang.Core.Compile.TypeCheck (primToType,primopToType,runCheck)
 import Hschain.Utxo.Lang.Expr ( Loc, noLoc, VarName(..), typeCoreToType, varT, funT, listT
-                              , arrowT, intT, boolT, textT, sigmaT
+                              , arrowT, intT, boolT, bytesT, sigmaT
                               , monoPrimopNameMap)
 
 import qualified Language.HM as H
@@ -169,7 +169,7 @@ annotateTypes =
 libTypeContext :: H.Context Loc Tag
 libTypeContext = (H.Context $ M.fromList
   [ (IfTag, forA $ funT [boolT, aT, aT] aT)
-  , (VarTag "pk", H.monoT $ funT [textT] sigmaT)
+  , (VarTag "pk", H.monoT $ funT [bytesT] sigmaT)
   , (VarTag "listAt", H.forAllT noLoc "a" $ H.monoT $ funT [listT (varT "a"), intT] (varT "a"))
   , (VarTag "length", H.forAllT noLoc "a" $ H.monoT $ funT [listT (varT "a")] intT)
   ])

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
@@ -195,7 +195,7 @@ primopToType = \case
   OpBoolXor -> pure $ BoolT :-> BoolT :-> BoolT
   OpBoolNot -> pure $ BoolT :-> BoolT
   --
-  OpSigPK        -> pure $ TextT  :-> SigmaT
+  OpSigPK        -> pure $ BytesT :-> SigmaT
   OpSigBool      -> pure $ BoolT  :-> SigmaT
   OpSigAnd       -> pure $ SigmaT :-> SigmaT :-> SigmaT
   OpSigOr        -> pure $ SigmaT :-> SigmaT :-> SigmaT
@@ -204,8 +204,8 @@ primopToType = \case
   OpSigListAll a -> pure $ (a :-> SigmaT) :-> ListT a :-> SigmaT
   OpSigListAny a -> pure $ (a :-> SigmaT) :-> ListT a :-> SigmaT
   --
-  OpCheckSig      -> pure $ TextT :-> IntT :-> BoolT
-  OpCheckMultiSig -> pure $ IntT :-> ListT TextT :-> ListT IntT :-> BoolT
+  OpCheckSig      -> pure $ BytesT :-> IntT :-> BoolT
+  OpCheckMultiSig -> pure $ IntT :-> ListT BytesT :-> ListT IntT :-> BoolT
   --
   OpSHA256      -> pure $ BytesT :-> BytesT
   OpTextLength  -> pure $ TextT  :-> IntT
@@ -253,7 +253,7 @@ primopToType = \case
     tagToType = \case
       IntArg   -> IntT
       BoolArg  -> BoolT
-      TextArg  ->TextT
+      TextArg  -> TextT
       BytesArg -> BytesT
 
 compareType :: TypeCore -> Check TypeCore

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Infer.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Infer.hs
@@ -262,7 +262,7 @@ defaultContext = H.Context $ M.fromList $
   -- if
   , (ifVar,     forA $ monoT $ boolT `arr` (a `arr` (a `arr` a)))
   -- pk
-  , (pkVar,     monoT $ textT `arr` sigmaT)
+  , (pkVar,     monoT $ bytesT `arr` sigmaT)
   -- operations
   --  unary
   , (notVar,    monoT $ boolT `arr` boolT)

--- a/hschain-utxo-lang/test/TM/Tx/Sigma.hs
+++ b/hschain-utxo-lang/test/TM/Tx/Sigma.hs
@@ -6,7 +6,7 @@ module TM.Tx.Sigma(
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import HSChain.Crypto (hashBlob)
+import HSChain.Crypto (hashBlob,ByteRepr(..))
 import Hschain.Utxo.Lang.Sigma
 import Hschain.Utxo.Lang.Build
 import Hschain.Utxo.Lang.Types
@@ -30,7 +30,7 @@ initTx = do
       { tx'inputs  = singleOwnerInput (BoxId $ hashBlob "box-1") pubKey
       , tx'outputs = return $ Box
           { box'value  = 1
-          , box'script = mainScriptUnsafe $ pk $ text $ publicKeyToText pubKey
+          , box'script = mainScriptUnsafe $ pk $ bytes $ encodeToBS pubKey
           , box'args   = mempty
           }
       }
@@ -47,7 +47,7 @@ bobStealsTx aliceTx = do
   let bobPubKey = getPublicKey bobSecret
       -- robbery happens: we substitute ownership of all boxes to Bob's key
       stealScript box = box
-        { box'script = mainScriptUnsafe $ pk $ text $ publicKeyToText bobPubKey
+        { box'script = mainScriptUnsafe $ pk $ bytes $ encodeToBS bobPubKey
         }
   return $ aliceTx
     { tx'outputs = fmap stealScript $ tx'outputs aliceTx

--- a/hschain-utxo-lang/test/TM/Tx/Sign.hs
+++ b/hschain-utxo-lang/test/TM/Tx/Sign.hs
@@ -53,7 +53,7 @@ testByteReprSignature = do
 
 
 pkExpr :: PublicKey -> ExprCore
-pkExpr = text . publicKeyToText
+pkExpr = bytes . encodeToBS
 
 testCheckSig :: IO Bool
 testCheckSig = do
@@ -71,7 +71,7 @@ testCheckMultiSig sigCount = do
   let pubKeys = fmap getPublicKey privKeys
   -- all signatures but first dropCount keys are present, and we duplicate first signature as fill in
   env <- inputEnv (dupFirst $ dropPrivs privKeys) testMsg
-  let script = checkMultiSig (int 2) (listExpr TextT $ fmap pkExpr pubKeys) (listExpr IntT $ fmap int [0, 1, 2])
+  let script = checkMultiSig (int 2) (listExpr BytesT $ fmap pkExpr pubKeys) (listExpr IntT $ fmap int [0, 1, 2])
   return $ evalProg env script == EvalPrim (PrimBool True)
   where
     dropCount = 3 - sigCount

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/XorGame.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/XorGame.hs
@@ -15,6 +15,7 @@ import Data.Text (Text)
 
 import System.Random
 
+import HSChain.Crypto (ByteRepr(..))
 import Hschain.Utxo.API.Rest
 import Hschain.Utxo.Lang
 import Hschain.Utxo.Lang.Build
@@ -42,8 +43,8 @@ getBobGuess box = listAt (getBoxIntArgList box) bobGuessFieldId
 getBobDeadline :: Expr Box -> Expr Int
 getBobDeadline box = listAt (getBoxIntArgList box) bobDeadlineFieldId
 
-getBobPk :: Expr Box -> Expr Text
-getBobPk box = listAt (getBoxTextArgList box) bobPkFieldId
+getBobPk :: Expr Box -> Expr ByteString
+getBobPk box = listAt (getBoxBytesArgList box) bobPkFieldId
 
 getS :: Expr ByteString
 getS = listAt getBytesVars sFieldId
@@ -68,7 +69,7 @@ halfGameScript fullGameScriptHash =
   &&* (bobDeadline >=* getHeight + 30)
   &&* (getBoxValue out >=* 2 * getBoxValue getSelf )
 
-fullGameScript :: Expr ByteString -> Expr Text -> Expr SigmaBool
+fullGameScript :: Expr ByteString -> Expr ByteString -> Expr SigmaBool
 fullGameScript k alice =
   "s"              =: getS                               $ \(s :: Expr ByteString) ->
   "a"              =: getA                               $ \(a :: Expr Int) ->
@@ -115,7 +116,7 @@ xorGameRound Scene{..} game@Game{..} = do
       Just bobBox1   = user'box scene'bob
   mAliceScript <- getAliceScript (guess'alice game'guess) alice aliceBox1
   res <- fmap join $ forM mAliceScript $ \(alicePublicHash, scriptBox, _aliceBox2, aliceSecret) -> do
-    mBobScript <- getBobScript (fromIntegral $ guess'bob game'guess) bob alicePublicHash scriptBox (publicKeyToText $ getWalletPublicKey alice) bobBox1
+    mBobScript <- getBobScript (fromIntegral $ guess'bob game'guess) bob alicePublicHash scriptBox (encodeToBS $ getWalletPublicKey alice) bobBox1
     forM mBobScript $ \(gameBox, _bobBox2) -> do
       aliceRes <- triesToWin (isAliceWin game) "Alice" alice gameBox aliceSecret (fromIntegral $ guess'alice game'guess)
       bobRes   <- triesToWin (isBobWin   game) "Bob"   bob   gameBox aliceSecret (fromIntegral $ guess'alice game'guess)
@@ -127,7 +128,7 @@ xorGameRound Scene{..} game@Game{..} = do
   where
     getAliceScript guess wallet@Wallet{..} box = do
       (k, s) <- makeAliceSecret guess
-      let fullScriptHash = hashScript $ mainScriptUnsafe $ fullGameScript (bytes k) (text $ publicKeyToText $ getWalletPublicKey wallet)
+      let fullScriptHash = hashScript $ mainScriptUnsafe $ fullGameScript (bytes k) (bytes $ encodeToBS $ getWalletPublicKey wallet)
           aliceScript = halfGameScript $ bytes $ fullScriptHash
       (tx, backAddr, gameAddr) <- makeAliceTx game'amount aliceScript wallet box
       eTx <- postTxDebug True "Alice posts half game script" tx
@@ -200,7 +201,7 @@ xorGameRound Scene{..} game@Game{..} = do
               | total < game'amount = Nothing
               | otherwise           = Just Box
                   { box'value   = 2 * game'amount
-                  , box'script  = mainScriptUnsafe $ fullGameScript (bytes alicePublicHash) (text alicePubKey)
+                  , box'script  = mainScriptUnsafe $ fullGameScript (bytes alicePublicHash) (bytes alicePubKey)
                   , box'args    = makeArgs height
                   }
 
@@ -208,11 +209,11 @@ xorGameRound Scene{..} game@Game{..} = do
               | total <= game'amount = Nothing
               | otherwise            = Just Box
                   { box'value  = total - game'amount
-                  , box'script = mainScriptUnsafe $ pk $ text $ publicKeyToText $ getWalletPublicKey wallet
+                  , box'script = mainScriptUnsafe $ pk $ bytes $ encodeToBS $ getWalletPublicKey wallet
                   , box'args   = mempty
                   }
 
-            makeArgs height = intArgs [guess, height + 35] <> textArgs [publicKeyToText $ getWalletPublicKey wallet]
+            makeArgs height = intArgs [guess, height + 35] <> byteArgs [encodeToBS $ getWalletPublicKey wallet]
 
             extractOutputs tx = case tx'outputs tx of
               [_receiver]          -> (toBoxId 0, Nothing)
@@ -243,7 +244,7 @@ xorGameRound Scene{..} game@Game{..} = do
 
         outBox = Box
           { box'value   = 2 * game'amount
-          , box'script  = mainScriptUnsafe $ pk $ text $ publicKeyToText $ getWalletPublicKey wallet
+          , box'script  = mainScriptUnsafe $ pk $ bytes $ encodeToBS $ getWalletPublicKey wallet
           , box'args    = mempty
           }
 

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
@@ -29,7 +29,7 @@ import Data.Maybe
 import Data.Text (Text)
 import Data.Vector (Vector)
 
-
+import HSChain.Crypto (ByteRepr(..))
 import Hschain.Utxo.Lang
 import Hschain.Utxo.Lang.Build
 import Hschain.Utxo.Test.Client.Monad
@@ -141,14 +141,14 @@ toSendTx wallet Send{..} SendBack{..} =
     senderUtxo
       | sendBack'totalAmount > send'amount = Just $ Box
                 { box'value  = sendBack'totalAmount - send'amount
-                , box'script = mainScriptUnsafe $ pk (text $ publicKeyToText $ getWalletPublicKey wallet)
+                , box'script = mainScriptUnsafe $ pk $ bytes $ encodeToBS $ getWalletPublicKey wallet
                 , box'args   = mempty
                 }
       | otherwise                 = Nothing
 
     receiverUtxo = Box
       { box'value  = send'amount
-      , box'script = mainScriptUnsafe $ pk (text $ publicKeyToText $ getWalletPublicKey send'recepientWallet)
+      , box'script = mainScriptUnsafe $ pk $ bytes $ encodeToBS $ getWalletPublicKey send'recepientWallet
       , box'args   = mempty
       }
 


### PR DESCRIPTION
Storing it as text is simply waste of valuable bytes

Сейчас тесты падают из-за того, чтогде в языке высоко уровня не сходятся. Прошу помощи @anton-k 