### PR TITLE
Remove PrimOps for high level lang

### DIFF
--- a/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
+++ b/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
@@ -63,7 +63,7 @@ compile input output = do
         Left  e      -> Left $ CoreScriptError $ TypeCoreError e
 
 checkType :: Module -> Maybe Error
-checkType = checkMainModule langTypeContext
+checkType = checkMainModule baseLibTypeContext
 
 ----------------------------------------
 -- generate secret

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Build.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Build.hs
@@ -14,14 +14,12 @@ module Hschain.Utxo.Lang.Build(
   , pk'
   , SigmaBool
   , toSigma
-  , sigmaAnd
-  , sigmaOr
   , getHeight
   , getSelf, getInput, getOutput
   , getBoxId, getBoxValue, getBoxScript, getBoxIntArgList, getBoxTextArgList, getBoxBoolArgList, getBoxBytesArgList, getBoxPostHeight
   , getInputs, getOutputs, getDataInputs
   , getIntVars, getBoolVars, getTextVars, getBytesVars
-  , fromVec, mapVec, foldlVec, lengthVec, allVec, anyVec, concatVec, listAt
+  , fromVec, mapVec, foldlVec, lengthVec, andVec, orVec, concatVec, listAt
   , andSigma, orSigma
   , checkSig
   , checkMultiSig
@@ -40,32 +38,33 @@ module Hschain.Utxo.Lang.Build(
   , serialiseBool
   , serialiseText
   , lengthBytes
-  , trace
   , pair
-  , pairAt1
-  , pairAt2
   , tuple3
   , tuple4
 ) where
 
+import Data.Text (Text)
+
+import Hschain.Utxo.Lang.Compile
+import Hschain.Utxo.Lang.Desugar
+import Hschain.Utxo.Lang.Expr
+import Hschain.Utxo.Lang.Error
+import Hschain.Utxo.Lang.Pretty
+import Hschain.Utxo.Lang.Types
+
+import qualified Data.Text   as T
 import Data.Boolean
 import Data.ByteString (ByteString)
 import Data.Fix
 import Data.String
-import Data.Text (Text)
 import Data.Vector (Vector)
 
-import qualified Data.Text   as T
 import qualified Data.Vector as V
 
 import HSChain.Crypto (ByteRepr(..))
-import Hschain.Utxo.Lang.Compile
-import Hschain.Utxo.Lang.Desugar
-import Hschain.Utxo.Lang.Error
-import Hschain.Utxo.Lang.Pretty
 import Hschain.Utxo.Lang.Sigma (PublicKey)
-import Hschain.Utxo.Lang.Types
-import Hschain.Utxo.Lang.Expr
+
+import qualified Hschain.Utxo.Lang.Const as Const
 
 -- | Creates module  out of single main expression and ignores the errors of compilation.
 mainScriptUnsafe :: Expr SigmaBool -> Script
@@ -103,11 +102,25 @@ bytes x = primExpr $ PrimBytes x
 mkBool :: Bool -> Expr Bool
 mkBool x = primExpr $ PrimBool x
 
-op1 :: (Lang -> E Lang) -> Expr a -> Expr b
-op1 f (Expr a) = Expr $ Fix $ f a
+primAp1 :: Text -> Expr a -> Expr b
+primAp1 = primOp1
 
-op2 :: (Lang -> Lang -> E Lang) -> Expr a -> Expr b -> Expr c
-op2 f (Expr a) (Expr b) = Expr $ Fix $ f a b
+primAp2 :: Text -> Expr a -> Expr b -> Expr c
+primAp2 name a (Expr b) = case primAp1 name a of
+  Expr f -> Expr $ Fix $ Apply noLoc f b
+
+primAp3 :: Text -> Expr a -> Expr b -> Expr c -> Expr d
+primAp3 name a b (Expr c) = case primAp2 name a b of
+  Expr f -> Expr $ Fix $ Apply noLoc f c
+
+primVar :: Text -> Expr a
+primVar name = Expr $ Fix $ Var noLoc $ VarName noLoc name
+
+primOp1 :: Text -> Expr a -> Expr b
+primOp1 name (Expr a) = Expr $ Fix $ Apply noLoc (Fix $ Var noLoc (VarName noLoc name)) a
+
+primOp2 :: Text -> Expr a -> Expr b -> Expr c
+primOp2 name (Expr a) (Expr b) = Expr $ Fix $ InfixApply noLoc a (VarName noLoc name) b
 
 -- variables
 
@@ -135,12 +148,6 @@ app (Expr fun) (Expr arg) = Expr $ Fix $ Apply noLoc fun arg
 pair :: Expr a -> Expr b -> Expr (a, b)
 pair (Expr a) (Expr b) = Expr $ Fix $ Tuple noLoc $ V.fromList [a, b]
 
-pairAt1 :: Expr (a, b) -> Expr a
-pairAt1 (Expr a) = Expr $ Fix $ UnOpE noLoc (TupleAt 2 0) a
-
-pairAt2 :: Expr (a, b) -> Expr b
-pairAt2 (Expr a) = Expr $ Fix $ UnOpE noLoc (TupleAt 2 1) a
-
 tuple3 :: Expr a -> Expr b -> Expr c -> Expr (a, b, c)
 tuple3 (Expr a) (Expr b) (Expr c) = Expr $ Fix $ Tuple noLoc $ V.fromList [a, b, c]
 
@@ -160,118 +167,112 @@ instance IsString (Expr Text) where
 instance Boolean (Expr Bool) where
   true = mkBool True
   false = mkBool False
-  notB = op1 (UnOpE noLoc Not)
-  (&&*) = op2 (BinOpE noLoc And)
-  (||*) = op2 (BinOpE noLoc Or)
+  notB = primOp1 "not"
+  (&&*) = primOp2 "&&"
+  (||*) = primOp2 "||"
 
 instance Boolean (Expr SigmaBool) where
   true  = toSigma true
   false = toSigma false
   notB = error "Not is not defined for sigma-expressions"
-  (&&*) = sigmaAnd
-  (||*) = sigmaOr
+  (&&*) = primOp2 Const.sigmaAnd
+  (||*) = primOp2 Const.sigmaOr
 
 pk' :: PublicKey -> Expr SigmaBool
 pk' = pk . bytes . encodeToBS
 
 pk :: Expr ByteString -> Expr SigmaBool
-pk (Expr key) = Expr $ Fix $ SigmaE noLoc $ Pk noLoc key
-
-sigmaAnd :: Expr SigmaBool -> Expr SigmaBool -> Expr SigmaBool
-sigmaAnd (Expr a) (Expr b) = Expr $ Fix $ SigmaE noLoc $ SAnd noLoc a b
-
-sigmaOr :: Expr SigmaBool -> Expr SigmaBool -> Expr SigmaBool
-sigmaOr (Expr a) (Expr b) = Expr $ Fix $ SigmaE noLoc $ SOr noLoc a b
+pk = primAp1 Const.pk
 
 toSigma :: Expr Bool -> Expr SigmaBool
-toSigma (Expr x) = Expr $ Fix $ SigmaE noLoc $ SPrimBool noLoc x
+toSigma = primAp1 Const.toSigma
 
 getSelf :: Expr Box
-getSelf = Expr $ Fix $ GetEnv noLoc (Self noLoc)
+getSelf = primVar Const.getSelf
 
 getInput :: Expr Int -> Expr Box
-getInput (Expr n) = Expr $ Fix $ GetEnv noLoc $ Input noLoc n
+getInput = primAp1 Const.getInput
 
 getOutput :: Expr Int -> Expr Box
-getOutput (Expr n) = Expr $ Fix $ GetEnv noLoc $ Output noLoc n
+getOutput = primAp1 Const.getOutput
 
 getBoxId :: Expr Box -> Expr Text
-getBoxId (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box BoxFieldId
+getBoxId = primAp1 Const.getBoxId
 
 getBoxValue :: Expr Box -> Expr Int
-getBoxValue (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box BoxFieldValue
+getBoxValue = primAp1 Const.getBoxValue
 
 getBoxScript :: Expr Box -> Expr ByteString
-getBoxScript (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box BoxFieldScript
+getBoxScript = primAp1 Const.getBoxScript
 
 getBoxPostHeight :: Expr Box -> Expr Int
-getBoxPostHeight (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box BoxFieldPostHeight
+getBoxPostHeight = primAp1 Const.getBoxPostHeight
 
 getBoxBytesArgList :: Expr Box -> Expr (Vector ByteString)
-getBoxBytesArgList (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box (BoxFieldArgList BytesArg)
+getBoxBytesArgList = primAp1 $ Const.getBoxArgs (argTypeName BytesArg)
 
 getBoxIntArgList :: Expr Box -> Expr (Vector Int)
-getBoxIntArgList (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box (BoxFieldArgList IntArg)
+getBoxIntArgList = primAp1 $ Const.getBoxArgs (argTypeName IntArg)
 
 getBoxTextArgList :: Expr Box -> Expr (Vector Text)
-getBoxTextArgList (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box (BoxFieldArgList TextArg)
+getBoxTextArgList = primAp1 $ Const.getBoxArgs (argTypeName TextArg)
 
 getBoxBoolArgList :: Expr Box -> Expr (Vector Bool)
-getBoxBoolArgList (Expr box) = Expr $ Fix $ BoxE noLoc $ BoxAt noLoc box (BoxFieldArgList BoolArg)
+getBoxBoolArgList = primAp1 $ Const.getBoxArgs (argTypeName BoolArg)
 
 getHeight :: Expr Int
-getHeight = Expr $ Fix $ GetEnv noLoc (Height noLoc)
+getHeight = primVar Const.getHeight
 
 getIntVars :: Expr (Vector Int)
-getIntVars = Expr $ Fix $ GetEnv noLoc $ GetVar noLoc IntArg
+getIntVars = primVar $ Const.getArgs (argTypeName IntArg)
 
 getBoolVars :: Expr (Vector Bool)
-getBoolVars = Expr $ Fix $ GetEnv noLoc $ GetVar noLoc BoolArg
+getBoolVars = primVar $ Const.getArgs (argTypeName BoolArg)
 
 getTextVars :: Expr (Vector Text)
-getTextVars = Expr $ Fix $ GetEnv noLoc $ GetVar noLoc TextArg
+getTextVars = primVar $ Const.getArgs (argTypeName TextArg)
 
 getBytesVars :: Expr (Vector ByteString)
-getBytesVars = Expr $ Fix $ GetEnv noLoc $ GetVar noLoc BytesArg
+getBytesVars = primVar $ Const.getArgs (argTypeName BytesArg)
 
 getInputs :: Expr (Vector Box)
-getInputs = Expr $ Fix $ GetEnv noLoc (Inputs noLoc)
+getInputs = primVar Const.getInputs
 
 getOutputs :: Expr (Vector Box)
-getOutputs = Expr $ Fix $ GetEnv noLoc (Outputs noLoc)
+getOutputs = primVar Const.getOutputs
 
 getDataInputs :: Expr (Vector Box)
-getDataInputs = Expr $ Fix $ GetEnv noLoc (DataInputs noLoc)
+getDataInputs = primVar Const.getDataInputs
 
 fromVec :: Vector (Expr a) -> Expr (Vector a)
-fromVec vs = Expr $ Fix $ VecE noLoc $ NewVec noLoc $ fmap (\(Expr a) -> a) vs
+fromVec vs = Expr $ Fix $ List noLoc $ fmap (\(Expr a) -> a) vs
 
 listAt :: Expr (Vector a) -> Expr Int -> Expr a
-listAt (Expr vector) (Expr index) = Expr $ Fix $ VecE noLoc $ VecAt noLoc vector index
+listAt = primAp2 Const.listAt
 
 mapVec :: Expr (a -> b) -> Expr (Vector a) -> Expr (Vector b)
-mapVec (Expr f) (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Apply noLoc (Fix $ VecE noLoc (VecMap noLoc)) f) v
+mapVec = primAp2 Const.map
 
 foldlVec :: Expr (a -> b -> a) -> Expr a -> Expr (Vector b) -> Expr a
-foldlVec (Expr f) (Expr z) (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Apply noLoc (Fix $ Apply noLoc (Fix $ VecE noLoc (VecFoldl noLoc)) f) z) v
+foldlVec = primAp3 Const.foldl
 
 lengthVec :: Expr (Vector a) -> Expr Int
-lengthVec (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ VecE noLoc (VecLength noLoc)) v
+lengthVec = primAp1 Const.length
 
 concatVec :: Expr (Vector a) -> Expr (Vector a) -> Expr (Vector a)
-concatVec (Expr a) (Expr b) = Expr $ Fix $ VecE noLoc $ VecAppend noLoc a b
+concatVec = primOp2 Const.appendList
 
-allVec :: Expr (Vector Bool) -> Expr Bool
-allVec (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Var noLoc "all") v
+andVec :: Expr (Vector Bool) -> Expr Bool
+andVec = primAp1 Const.and
 
-anyVec :: Expr (Vector Bool) -> Expr Bool
-anyVec (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Var noLoc "any") v
+orVec :: Expr (Vector Bool) -> Expr Bool
+orVec = primAp1 Const.or
 
 andSigma :: Expr (Vector SigmaBool) -> Expr SigmaBool
-andSigma (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Var noLoc "andSigma") v
+andSigma = primAp1 Const.andSigma
 
 orSigma :: Expr (Vector SigmaBool) -> Expr SigmaBool
-orSigma (Expr v) = Expr $ Fix $ Apply noLoc (Fix $ Var noLoc "orSigma") v
+orSigma = primAp1 Const.orSigma
 
 type instance BooleanOf (Expr a) = Expr Bool
 
@@ -282,9 +283,9 @@ instance IfB (Expr a) where
 -- numeric
 
 instance Num (Expr Int) where
-  (+) = op2 (BinOpE noLoc Plus)
-  (*) = op2 (BinOpE noLoc Times)
-  negate = op1 (UnOpE noLoc Neg)
+  (+) = primOp2 "+"
+  (*) = primOp2 "*"
+  negate = primAp1 "negate"
   fromInteger n = primExpr $ PrimInt $ fromIntegral n
   abs = error "abs is not defined for Expr"
   signum = error "signum is not defined for Expr"
@@ -293,58 +294,68 @@ instance Num (Expr Int) where
 --
 
 instance EqB (Expr Int) where
-  (==*) = op2 (BinOpE noLoc Equals)
-  (/=*) = op2 (BinOpE noLoc NotEquals)
+  (==*) = primOp2 Const.equals
+  (/=*) = primOp2 Const.nonEquals
 
 instance EqB (Expr Text) where
-  (==*) = op2 (BinOpE noLoc Equals)
-  (/=*) = op2 (BinOpE noLoc NotEquals)
+  (==*) = primOp2 Const.equals
+  (/=*) = primOp2 Const.nonEquals
 
 instance EqB (Expr ByteString) where
-  (==*) = op2 (BinOpE noLoc Equals)
-  (/=*) = op2 (BinOpE noLoc NotEquals)
+  (==*) = primOp2 Const.equals
+  (/=*) = primOp2 Const.nonEquals
 
 instance EqB (Expr Script) where
-  (==*) = op2 (BinOpE noLoc Equals)
-  (/=*) = op2 (BinOpE noLoc NotEquals)
+  (==*) = primOp2 Const.equals
+  (/=*) = primOp2 Const.nonEquals
+
+instance EqB (Expr Bool) where
+  (==*) = primOp2 Const.equals
+  (/=*) = primOp2 Const.nonEquals
 
 -- order
 
 instance OrdB (Expr Int) where
-  (<*) = op2 (BinOpE noLoc LessThan)
+  (<*) = primOp2 Const.less
 
 instance OrdB (Expr Text) where
-  (<*) = op2 (BinOpE noLoc LessThan)
+  (<*) = primOp2 Const.less
+
+instance OrdB (Expr Bool) where
+  (<*) = primOp2 Const.less
 
 instance OrdB (Expr ByteString) where
-  (<*) = op2 (BinOpE noLoc LessThan)
+  (<*) = primOp2 Const.less
+
+instance OrdB (Expr Script) where
+  (<*) = primOp2 Const.less
 
 -------------------------
 -- btc-like signatures
 
 checkSig :: Expr ByteString -> Expr Int -> Expr Bool
-checkSig (Expr a) (Expr b) = Expr $ Fix $ CheckSig noLoc a b
+checkSig = primAp2 Const.checkSig
 
 checkMultiSig :: Expr Int -> Expr (Vector ByteString) -> Expr (Vector Int) -> Expr Bool
-checkMultiSig (Expr a) (Expr b) (Expr c) = Expr $ Fix $ CheckMultiSig noLoc a b c
+checkMultiSig = primAp3 Const.checkMultiSig
 
 --------------------------
 -- text
 
 concatText :: Expr Text -> Expr Text -> Expr Text
-concatText (Expr a) (Expr b) = Expr $ Fix $ TextE noLoc $ TextAppend noLoc a b
+concatText = primOp2 Const.appendText
 
 concatBytes :: Expr ByteString -> Expr ByteString -> Expr ByteString
-concatBytes (Expr a) (Expr b) = Expr $ Fix $ BytesE noLoc $ BytesAppend noLoc a b
+concatBytes = primAp2 Const.appendBytes
 
 lengthText :: Expr Text -> Expr Int
-lengthText (Expr a) = Expr $ Fix $ Apply noLoc (Fix $ TextE noLoc (TextLength noLoc)) a
+lengthText = primAp1 Const.lengthText
 
 showExpr :: Expr a -> Expr Text
-showExpr (Expr a) = Expr $ Fix $ Apply noLoc (Fix $ TextE noLoc (ConvertToText noLoc)) a
+showExpr = primAp1 Const.show
 
 sha256 :: Expr ByteString -> Expr ByteString
-sha256 (Expr a) = Expr $ Fix $ BytesE noLoc $ BytesHash noLoc Sha256 a
+sha256 = primAp1 Const.sha256
 
 serialiseInt :: Expr Int -> Expr ByteString
 serialiseInt = serialiseBy IntArg
@@ -359,10 +370,10 @@ serialiseBool :: Expr Bool -> Expr ByteString
 serialiseBool = serialiseBy BoolArg
 
 serialiseBy :: ArgType -> Expr a -> Expr ByteString
-serialiseBy tag (Expr expr) = Expr $ Fix $ BytesE noLoc $ SerialiseToBytes noLoc tag expr
+serialiseBy tag = primAp1 $ Const.serialiseBytes (argTypeName tag)
 
 lengthBytes :: Expr ByteString -> Expr Int
-lengthBytes (Expr a) = Expr $ Fix $ BytesE noLoc $ BytesLength noLoc a
+lengthBytes = primAp1 Const.lengthBytes
 
 -------------------------------
 -- monoids
@@ -382,8 +393,3 @@ instance Semigroup (Expr (Vector a)) where
 instance Monoid (Expr (Vector a)) where
   mempty = fromVec mempty
 
-------------------------------------
--- debug
-
-trace :: Expr Text -> Expr a -> Expr a
-trace (Expr str) (Expr a) = Expr $ Fix $ Trace noLoc str a

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile.hs
@@ -28,7 +28,7 @@ import Hschain.Utxo.Lang.Core.Compile.Expr (ExprCore, coreProgToScript)
 import Hschain.Utxo.Lang.Monad
 import Hschain.Utxo.Lang.Infer
 import Hschain.Utxo.Lang.Pretty
-import Hschain.Utxo.Lang.Lib.Base (baseLibTypeContext, baseLibExecContext)
+import Hschain.Utxo.Lang.Lib.Base (baseLibTypeContext, baseLibExecCtx)
 import Hschain.Utxo.Lang.Exec.Module (trimModuleByMain)
 
 import qualified Language.HM       as H
@@ -61,7 +61,7 @@ compile
 
 -- | Inlines all prelude functions
 inlinePrelude :: Module -> Module
-inlinePrelude = inlineExecCtx baseLibExecContext
+inlinePrelude = inlineExecCtx baseLibExecCtx
 
 -- | Reduces all simple applications:
 --

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Const.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Const.hs
@@ -5,6 +5,9 @@ module Hschain.Utxo.Lang.Const(
   -- * Environment
   , getHeight
   , getSelf
+  , getInput
+  , getOutput
+  , getDataInput
   , getInputs
   , getOutputs
   , getDataInputs
@@ -27,6 +30,8 @@ module Hschain.Utxo.Lang.Const(
   , sigmaLessEquals
   , sigmaEquals
   , sigmaNonEquals
+  -- * Nums
+  , negate
   -- * Comparisons
   , greater
   , less
@@ -67,9 +72,12 @@ module Hschain.Utxo.Lang.Const(
   , evalReductionLimit
 ) where
 
-import Prelude hiding (map, filter, foldr, foldl, length, show, all, any, and, or, sum, product)
+import Prelude hiding (map, filter, foldr, foldl, length, show, all, any, and, or, sum, product, negate)
 import Data.String
 import Data.Text (Text)
+
+negate :: IsString a => a
+negate = "negate"
 
 -- TODO: define all names for primitive functions in this module.
 -- right now we use it only for
@@ -82,13 +90,16 @@ import Data.Text (Text)
 ---------------------------------------------------------------
 -- names for functions that read environment
 
-getHeight, getSelf, getInputs, getOutputs, getDataInputs :: Text
+getHeight, getSelf, getInputs, getOutputs, getDataInputs, getInput, getOutput, getDataInput :: Text
 
 getHeight  = "getHeight"
 getSelf    = "getSelf"
 getInputs  = "getInputs"
 getOutputs = "getOutputs"
 getDataInputs = "getDataInputs"
+getInput  = "getInput"
+getOutput = "getOutput"
+getDataInput = "getDataInput"
 
 getArgs :: Text -> Text
 getArgs typeName = mconcat ["get", typeName, "Args"]

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Desugar.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Desugar.hs
@@ -15,8 +15,6 @@ module Hschain.Utxo.Lang.Desugar(
   , bindBodyToExpr
   , bindGroupToLet
   , simpleBind
-  , caseToLet
-  , reduceSubPats
   , desugarRecordUpdate
   , recordFieldUpdateFunName
   , module Hschain.Utxo.Lang.Desugar.FreshVar
@@ -25,10 +23,7 @@ module Hschain.Utxo.Lang.Desugar(
 ) where
 
 
-import Control.Monad.State.Strict
-
 import Data.Fix
-import Data.Text (Text)
 
 import Language.HM (getLoc)
 
@@ -39,7 +34,6 @@ import Hschain.Utxo.Lang.Desugar.PatternCompiler
 import Hschain.Utxo.Lang.Desugar.Records
 
 import qualified Data.List as L
-
 
 desugar :: MonadLang m => UserTypeCtx -> Lang -> m Lang
 desugar ctx expr = removeRecordCons ctx expr
@@ -81,58 +75,6 @@ simpleBind :: VarName -> Lang -> Bind Lang
 simpleBind v a = Bind v Nothing [Alt [] (UnguardedRhs a) Nothing]
 
 -----------------------------------------------------------------
-caseToLet :: MonadLang m =>
-  (ConsName -> Int -> Text) -> Loc -> Lang -> [CaseExpr Lang] -> m Lang
-caseToLet toSelectorName loc expr cases = do
-  v <- getFreshVar loc
-  fmap (Fix . Let loc [simpleBind v expr]) $ caseToLet' toSelectorName loc v cases
-
-caseToLet' :: MonadLang m =>
-  (ConsName -> Int -> Text) -> Loc -> VarName -> [CaseExpr Lang] -> m Lang
-caseToLet' toSelectorName topLoc var cases = fmap (foldr (\(loc, a) rest -> Fix $ AltE loc a rest) failCase) $ mapM fromCase cases
-  where
-    toVarExpr loc v = Fix $ Var loc $ VarName loc $ varName'name v
-
-    fromCase CaseExpr{..} = fmap (getLoc caseExpr'lhs, ) $ case caseExpr'lhs of
-      PVar ploc pvar -> return $ Fix $ Let ploc [simpleBind pvar $ toVarExpr ploc var] caseExpr'rhs
-      PWildCard _ -> return $ caseExpr'rhs
-      PPrim ploc p -> return $ Fix $ If ploc (eqPrim ploc var p) caseExpr'rhs failCase
-      PCons ploc cons pats ->
-        case pats of
-          [] -> constCons ploc cons
-          _  -> argCons ploc cons pats
-      PTuple ploc pats -> do
-        (vs, rhs') <- reduceSubPats pats caseExpr'rhs
-        let size = length vs
-            bg = zipWith (\n v -> simpleBind v (Fix $ UnOpE (varName'loc v) (TupleAt size n) $ toVarExpr ploc var)) [0..] vs
-        return $ Fix $ Let ploc bg rhs'
-      where
-        constCons ploc cons = return $
-          app2 (Fix $ Var ploc $ VarName ploc $ toSelectorName cons 0) (toVarExpr ploc var) caseExpr'rhs
-
-        argCons ploc cons pats = do
-          (vs, rhs') <- reduceSubPats pats caseExpr'rhs
-          let bg = zipWith (\n v -> simpleBind v (Fix $ Apply (varName'loc v) (selector ploc cons n) $ toVarExpr ploc var)) [0..] vs
-          return $ Fix $ Let ploc bg rhs'
-
-    selector ploc cons n = Fix $ Var ploc (VarName ploc (toSelectorName cons n))
-
-    failCase = Fix $ FailCase topLoc
-
-    eqPrim ploc v p = Fix $ BinOpE ploc Equals (toVarExpr ploc v) (Fix $ PrimE ploc p)
-
-reduceSubPats :: forall m . MonadLang m => [Pat] -> Lang -> m ([VarName], Lang)
-reduceSubPats pats rhs = runStateT (mapM go pats) rhs
-  where
-    go :: Pat -> StateT Lang m VarName
-    go pat = case pat of
-      PVar _ var -> return var
-      _          -> do
-        expr <- get
-        let loc = getLoc pat
-        var  <- lift $ getFreshVar loc
-        put $ Fix $ CaseOf loc (Fix $ Var loc var) $ [CaseExpr pat expr]
-        return var
 
 desugarRecordUpdate :: VarName -> Lang -> Lang -> Lang
 desugarRecordUpdate field val expr =
@@ -143,5 +85,4 @@ recordFieldUpdateFunName VarName{..} = VarName
   { varName'loc  = varName'loc
   , varName'name = secretVar $ mappend "update_" varName'name
   }
-
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Exec/Subst.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Exec/Subst.hs
@@ -22,8 +22,6 @@ subst (Fix body) varName sub = case body of
                            | otherwise     -> Fix $ Var loc e
   PrimE loc p                              -> Fix $ PrimE loc p
   Ascr loc lc t                            -> Fix $ Ascr loc (rec lc) t
-  UnOpE loc uo lc                          -> Fix $ UnOpE loc uo $ rec lc
-  BinOpE loc bo a b                        -> Fix $ BinOpE loc bo (rec a) (rec b)
   Apply loc a b                            -> Fix $ Apply loc (rec a) (rec b)
   InfixApply loc a v b     | v == varName  -> subInfix loc sub a b
   InfixApply loc a v b     | otherwise     -> Fix $ InfixApply loc (rec a) v (rec b)
@@ -32,22 +30,15 @@ subst (Fix body) varName sub = case body of
   Let loc bg e                             -> Fix $ Let loc (substBindGroup bg) (recBy (bindVars bg) e)
   PrimLet loc bg e                         -> Fix $ PrimLet loc (substPrimBindGeoup bg) (recBy (primBindVars bg) e)
   Tuple loc as                             -> Fix $ Tuple loc $ fmap rec as
-  GetEnv loc idx                           -> Fix $ GetEnv loc $ fmap rec idx
-  SigmaE loc sigma                         -> Fix $ SigmaE loc $ fmap rec sigma
-  VecE loc vec                             -> Fix $ VecE loc $ fmap rec vec
-  TextE loc txt                            -> Fix $ TextE loc $ fmap rec txt
-  BytesE loc txt                           -> Fix $ BytesE loc $ fmap rec txt
-  BoxE loc box                             -> Fix $ BoxE loc $ fmap rec box
+  List loc as                              -> Fix $ List loc $ fmap rec as
+  NegApp loc a                             -> Fix $ NegApp loc $ rec a
   LamList loc vs a                         -> Fix $ LamList loc vs $ recBy (foldMap freeVarsPat vs) a
-  Trace loc a b                            -> Fix $ Trace loc (rec a) (rec b)
   FailCase loc                             -> Fix $ FailCase loc
   AltE loc a b                             -> Fix $ AltE loc (rec a) (rec b)
   CaseOf loc expr cases                    -> Fix $ CaseOf loc (rec expr) (fmap substCase cases)
   Cons loc name vs                         -> Fix $ Cons loc name $ fmap rec vs
   RecConstr loc name vals                  -> Fix $ RecConstr loc name (fmap (second rec) vals)
   RecUpdate loc a upds                     -> Fix $ RecUpdate loc (rec a) (fmap (second rec) upds)
-  CheckSig loc a b                         -> Fix $ CheckSig loc (rec a) (rec b)
-  CheckMultiSig loc a b c                  -> Fix $ CheckMultiSig loc (rec a) (rec b) (rec c)
   AntiQuote loc ty v                       -> Fix $ AntiQuote loc ty v
   where
     subInfix loc op a b = rec $ Fix (Apply loc (Fix $ Apply loc op a) b)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -371,35 +371,10 @@ data E a
   -- ^ if-expressions (@if cond then a else b@)
   | Tuple Loc (Vector a)
   -- ^ Tuple constructor with list of arguments (@(a, b, c)@)
-  -- operations
-  | UnOpE Loc UnOp a
-  -- ^ Application of built-in unary operator to arguments
-  | BinOpE Loc BinOp a a
-  -- ^ Application of built-in binary operator to arguments
-  -- environment
-  | GetEnv Loc (EnvId a)
-  -- ^ query some item by id in blockchain environment (@getEnvField@)
-  -- vectors
-  | SigmaE Loc (SigmaExpr a)
-  -- ^ Sigma-expressions
-  | VecE Loc (VecExpr a)
-  -- ^ Vector expression
-  -- text
-  | TextE Loc (TextExpr a)
-  -- ^ Text expression
-  -- Bytes
-  | BytesE Loc (BytesExpr a)
-  -- ^ bytes expression
-  -- boxes
-  | BoxE Loc (BoxExpr a)
-  -- ^ Box-expression
-  | CheckSig Loc a a
-  -- ^ check signature. Arguments are: public key as byte string and index of boxInput'sigs vector (of signatures)
-  | CheckMultiSig Loc a a a
-  -- ^ check multi-signature M out of N. Arguments are: number of signatures o be valid, list of public keys as texts, list of indices to boxInput'sigs vector (of signatures)
-  -- debug
-  | Trace Loc a a
-  -- ^ Trace print for debug of execution (@trace printMessage value@)
+  | List Loc (Vector a)
+  -- ^ List constructor with list of arguments (@[a, b, c]@)
+  | NegApp Loc a
+  -- ^ unary negation sign
   | AntiQuote Loc (Maybe QuoteType) VarName
   -- ^ reference to external vriables (used in quasi quoting)
   deriving (Eq, Show, Functor, Foldable, Traversable, Data, Typeable)
@@ -474,82 +449,6 @@ secretVar = flip mappend "___"
 
 -- | Type tag for type-safe construction
 data SigmaBool
-
--- | Sigma-expressions
-data SigmaExpr a
-  = Pk Loc a         -- ^ key ownership
-  | SAnd Loc a a     -- ^ sigma and
-  | SOr Loc a a      -- ^ sigma or
-  | SPrimBool Loc a  -- ^ constant bool
-  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Typeable)
-
--- | Expressions that operate on vectors
-data VecExpr a
-  = NewVec Loc (Vector a)
-  -- ^ Vector conxtructor from the list of values (@[a, b, c]@)
-  | VecAppend Loc a a
-  -- ^ Append two vectors (@as ++ bs@)
-  | VecAt Loc a a
-  -- ^ Get value from the vector by index (@as !! n@)
-  | VecLength Loc
-  -- ^ Get length of the vector (@length as@)
-  | VecMap Loc
-  -- ^ map vector with the function (@map f as@)
-  | VecFoldl Loc
-  -- ^ Left-fold vector with function and accumulator (@foldl f z as@)
-  | VecFoldr Loc
-  -- ^ Right-fold vector with function and accumulator (@foldr f z as@)
-  | VecFilter Loc
-  -- ^ filter vector with function and accumulator (@filter f z as@)
-  | VecAnd Loc
-  -- ^ and of vector of boolean expressions
-  | VecOr Loc
-  -- ^ or of vector of boolean expressions
-  | VecAndSigma Loc
-  -- ^ and of vector of sigma expressions
-  | VecOrSigma Loc
-  -- ^ or of vector of sigma expressions
-  | VecAny Loc
-  -- ^ any of vector of boolean expressions
-  | VecAll Loc
-  -- ^ all of vector of boolean expressions
-  | VecAnySigma Loc
-  -- ^ any of vector of sigma expressions
-  | VecAllSigma Loc
-  -- ^ or of vector of sigma expressions
-  | VecSum Loc
-  -- ^ sum of list of integers
-  | VecProduct Loc
-  -- ^ product of list of integers
-  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Typeable)
-
--- | Expressions that operate on texts.
-data TextExpr a
-  = TextAppend Loc a a
-  -- ^ Append text values (@a <> b@)
-  | ConvertToText Loc
-  -- ^ Convert some value to text (@show a@)
-  | TextLength Loc
-  -- ^ Get textlength (@lengthText a@)
-  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Typeable)
-
-data BytesExpr a
-  = BytesAppend Loc a a
-  -- ^ append bytes
-  | BytesLength Loc a
-  -- ^ size of byteString
-  | SerialiseToBytes Loc ArgType a
-  -- ^ serialise primitive types to bytes
-  | DeserialiseFromBytes Loc ArgType a
-  -- ^ deserialise values from bytes
-  | BytesHash Loc HashAlgo a
-  -- ^ get hash for the given ByteString.
-  deriving (Eq, Show, Functor, Foldable, Traversable, Data, Typeable)
-
--- | Hashing algorithm tag
-data HashAlgo
-  = Sha256
-  deriving (Eq, Show, Data, Typeable)
 
 -- | Primitive values of the language (constants).
 data Prim
@@ -730,26 +629,11 @@ instance Show a => H.HasLoc (E a) where
     If loc _ _ _ -> loc
     -- tuples
     Tuple loc _ -> loc
+    -- lists
+    List loc _ -> loc
+    -- unary negation
+    NegApp loc _ -> loc
     -- operations
-    UnOpE loc _ _ -> loc
-    BinOpE loc _ _ _ -> loc
-    -- environment
-    GetEnv loc _ -> loc
-    -- sigmas
-    SigmaE loc _ -> loc
-    -- vectors
-    VecE loc _ -> loc
-    -- text
-    TextE loc _ -> loc
-    -- bytes
-    BytesE loc _ -> loc
-    -- boxes
-    BoxE loc _ -> loc
-    -- BTC-style signatures
-    CheckSig loc _ _ -> loc
-    CheckMultiSig loc _ _ _ -> loc
-    -- debug
-    Trace loc _ _ -> loc
     AltE loc _ _ -> loc
     FailCase loc -> loc
     AntiQuote loc _ _ -> loc
@@ -807,18 +691,9 @@ freeVars = cata $ \case
   PrimE _ _        -> Set.empty
   If _ a b c       -> mconcat [a, b, c]
   Tuple _ vs       -> fold $ V.toList vs
-  UnOpE _ _ a      -> a
-  BinOpE _ _ a b   -> mconcat [a, b]
-  GetEnv _ env     -> fold env
-  SigmaE _ sigma   -> fold sigma
-  VecE _ vec       -> fold vec
-  TextE _ txt      -> fold txt
-  BytesE _ bs      -> fold bs
-  BoxE _ box       -> fold box
-  Trace _ a b      -> mconcat [a, b]
+  List _ vs        -> fold $ V.toList vs
+  NegApp _ a       -> a
   AltE _ a b       -> mappend a b
-  CheckSig _ a b   -> a <> b
-  CheckMultiSig _ a b c -> a <> b <> c
   FailCase _       -> Set.empty
   AntiQuote _ _ v  -> Set.singleton v
   where
@@ -1046,7 +921,7 @@ instance ToLang Int64 where
   toLang loc n = toPrim loc $ PrimInt n
 
 instance ToLang a => ToLang [a] where
-  toLang loc vals = Fix $ VecE loc $ NewVec loc $ V.fromList $ fmap (toLang loc) vals
+  toLang loc vals = Fix $ List loc $ V.fromList $ fmap (toLang loc) vals
 
 instance (ToLang a, ToLang b) => ToLang (a, b) where
   toLang loc (a, b) = Fix $ Tuple loc $ V.fromList [toLang loc a, toLang loc b]
@@ -1069,11 +944,6 @@ $(deriveShow1 ''Bind)
 $(deriveShow1 ''E)
 $(deriveShow1 ''EnvId)
 $(deriveShow1 ''CaseExpr)
-$(deriveShow1 ''TextExpr)
-$(deriveShow1 ''BytesExpr)
-$(deriveShow1 ''SigmaExpr)
-$(deriveShow1 ''VecExpr)
-$(deriveShow1 ''BoxExpr)
 
 instance H.IsVar Text where
   intToVar = H.stringIntToVar

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Infer.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Infer.hs
@@ -23,8 +23,8 @@ import Language.HM (appE, varE, lamE, conT, monoT, forAllT, stripSignature)
 
 import Hschain.Utxo.Lang.Desugar hiding (app1, app2, app3)
 import Hschain.Utxo.Lang.Expr
-import Hschain.Utxo.Lang.Types  (ArgType(..), argTypes)
 import Hschain.Utxo.Lang.Monad
+import Hschain.Utxo.Lang.Lib.Base (baseLibTypeContext)
 
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -33,6 +33,7 @@ import qualified Data.Vector as V
 import qualified Language.HM as H
 
 import qualified Hschain.Utxo.Lang.Const as Const
+import qualified Hschain.Utxo.Lang.Desugar as D
 
 data EmptyPrim = EmptyPrim
   deriving (Show)
@@ -64,7 +65,7 @@ maxTupleSize = 6
 -- and expression ot infer the type.
 inferExpr :: InferCtx -> Lang -> InferM Type
 inferExpr (InferCtx typeCtx userTypes) =
-  (InferM . lift . eitherTypeError . H.inferType (defaultContext <> typeCtx)) <=< reduceExpr userTypes
+  (InferM . lift . eitherTypeError . H.inferType (baseLibTypeContext <> defaultContext <> typeCtx)) <=< reduceExpr userTypes
 
 -- | Convert expression of our language to term of simpler language
 -- that can be type-checked by the library.
@@ -88,26 +89,9 @@ reduceExpr ctx@UserTypeCtx{..} (Fix expr) = case expr of
   PrimE loc prim            -> pure $ fromPrim loc prim
   If loc cond t e           -> liftA3 (fromIf loc) (rec cond) (rec t) (rec e)
   -- operations
-  UnOpE loc unOp a          -> fmap (fromUnOp loc unOp) (rec a)
-  BinOpE loc binOp a b      -> liftA2 (fromBinOp loc binOp) (rec a) (rec b)
   Tuple loc vs              -> fmap (fromTuple loc) $ mapM rec vs
-  -- sigmas
-  SigmaE loc sigma          -> fmap (fromSigma loc) $ mapM rec sigma
-  -- vectors
-  VecE loc v                -> fmap (fromVec loc) $ mapM rec v
-  -- text
-  TextE loc txt             -> fmap (fromText loc) $ mapM rec txt
-  -- text
-  BytesE loc txt            -> fmap (fromBytes loc) $ mapM rec txt
-  -- boxes
-  BoxE loc box              -> fmap (fromBox loc) $ mapM rec box
-  -- debug
-  Trace loc a b             -> liftA2 (fromTrace loc) (rec a) (rec b)
-  -- environment
-  GetEnv loc envId          -> fmap (fromGetEnv loc) $ mapM rec envId
-  -- btc-style signatures
-  CheckSig loc a b          -> liftA2 (app2 loc checkSigVar) (rec a) (rec b)
-  CheckMultiSig loc a b c   -> liftA3 (app3 loc checkMultiSigVar) (rec a) (rec b) (rec c)
+  List loc vs               -> fmap (fromList loc) $ mapM rec vs
+  NegApp loc a              -> fmap (appE loc (varE loc "negate")) (rec a)
   AltE loc a b              -> liftA2 (app2 loc altVar) (rec a) (rec b)
   FailCase loc              -> return $ varE loc failCaseVar
   -- records
@@ -159,99 +143,12 @@ reduceExpr ctx@UserTypeCtx{..} (Fix expr) = case expr of
 
     fromIf loc cond t e = app3 loc ifVar cond t e
 
-    fromPk loc a = appE loc (varE loc pkVar) a
-
-    fromUnOp loc op a = case op of
-      Not              -> not' a
-      Neg              -> negate' a
-      TupleAt size idx -> tupleAt size idx a
-      where
-        not' = appE loc (varE loc notVar)
-        negate' = appE loc (varE loc negateVar)
-        tupleAt size n = appE loc (varE loc $ tupleAtVar size n)
-
-    fromBinOp loc op = op2 $ case op of
-      And                 -> andVar
-      Or                  -> orVar
-      Plus                -> plusVar
-      Minus               -> minusVar
-      Times               -> timesVar
-      Div                 -> divVar
-      Equals              -> equalsVar
-      NotEquals           -> notEqualsVar
-      LessThan            -> lessThanVar
-      GreaterThan         -> greaterThanVar
-      LessThanEquals      -> lessThanEqualsVar
-      GreaterThanEquals   -> greaterThanEqualsVar
-      where
-        op2 = app2 loc
-
     fromTuple loc vs = appNs loc (tupleConVar size) $ V.toList vs
       where
         size = V.length vs
 
-    fromSigma _ = \case
-      Pk loc a         -> fromPk loc a
-      SAnd loc a b     -> app2 loc sigmaAndVar a b
-      SOr loc a b      -> app2 loc sigmaOrVar a b
-      SPrimBool loc a  -> app1 loc toSigmaVar a
+    fromList loc vs = V.foldr (consVec loc) (nilVec loc) vs
 
-    fromVec _ = \case
-      NewVec loc vs      -> V.foldr (consVec loc) (nilVec loc) vs
-      VecAppend loc a b  -> app2 loc appendVecVar a b
-      VecAt loc a n      -> app2 loc vecAtVar a n
-      VecLength loc      -> varE loc lengthVecVar
-      VecMap loc         -> varE loc mapVecVar
-      VecFoldl loc       -> varE loc foldlVecVar
-      VecFoldr loc       -> varE loc foldrVecVar
-      VecFilter loc      -> varE loc filterVecVar
-      VecAnd loc         -> varE loc andVecVar
-      VecOr loc          -> varE loc orVecVar
-      VecSum loc         -> varE loc sumVecVar
-      VecProduct loc     -> varE loc productVecVar
-      VecAndSigma loc    -> varE loc andSigmaVecVar
-      VecOrSigma loc     -> varE loc orSigmaVecVar
-      VecAny loc         -> varE loc anyVecVar
-      VecAll loc         -> varE loc allVecVar
-      VecAnySigma loc    -> varE loc anySigmaVecVar
-      VecAllSigma loc    -> varE loc allSigmaVecVar
-
-
-    fromText _ = \case
-      TextAppend loc a b -> app2 loc appendTextVar a b
-      ConvertToText loc  -> varE loc convertToTextVar
-      TextLength loc     -> varE loc lengthTextVar
-
-    fromBytes _ = \case
-      BytesAppend loc a b            -> app2 loc appendBytesVar a b
-      BytesLength loc a              -> app1 loc lengthBytesVar a
-      SerialiseToBytes loc tag a     -> app1 loc (serialiseToBytesVar tag) a
-      DeserialiseFromBytes loc tag a -> app1 loc (deserialiseToBytesVar tag) a
-      BytesHash loc hashAlgo a       -> app1 loc (bytesHashVar hashAlgo) a
-
-    fromBox _ = \case
-      BoxAt loc a field -> fromBoxField loc a field
-
-    fromBoxField loc a field = case field of
-      BoxFieldId         -> app1 loc getBoxIdVar a
-      BoxFieldValue      -> app1 loc getBoxValueVar a
-      BoxFieldScript     -> app1 loc getBoxScriptVar a
-      BoxFieldArgList ty -> app1 loc (getBoxArgVar' ty) a
-      BoxFieldPostHeight -> app1 loc getBoxPostHeightVar a
-
-    fromTrace loc msg a = app2 loc traceVar msg a
-
-    fromGetEnv _ = \case
-      Height loc     -> varE loc heightVar
-      Input loc  a   -> app1 loc inputVar a
-      Output loc a   -> app1 loc outputVar a
-      Self loc       -> varE loc selfVar
-      Inputs loc     -> varE loc inputsVar
-      Outputs loc    -> varE loc outputsVar
-      DataInputs loc -> varE loc dataInputsVar
-      GetVar loc ty  -> varE loc (getEnvVarName ty)
-
-    app1 loc var a = appE loc (varE loc var) a
     app2 loc var a b = appE loc (appE loc (varE loc var) a) b
     app3 loc var a b c = appE loc (app2 loc var a b) c
     appNs loc var as = foldl (\con a -> appE loc con a) (varE loc var) as
@@ -274,84 +171,16 @@ defaultContext = H.Context $ M.fromList $
   , (bytesVar,  monoT bytesT)
   -- if
   , (ifVar,     forA $ monoT $ boolT `arr` (a `arr` (a `arr` a)))
-  -- pk
-  , (pkVar,     monoT $ bytesT `arr` sigmaT)
-  -- operations
-  --  unary
-  , (notVar,    monoT $ boolT `arr` boolT)
-  , (negateVar, monoT $ intT `arr` intT)
-  -- binary
-  , (andVar,    boolOp2)
-  , (orVar,     boolOp2)
-  , (xorVar,     boolOp2)
-  , (plusVar,   intOp2)
-  , (minusVar,  intOp2)
-  , (timesVar,  intOp2)
-  , (divVar,    intOp2)
-  , (equalsVar, cmpOp2 )
-  , (notEqualsVar, cmpOp2)
-  , (lessThanVar, cmpOp2)
-  , (greaterThanVar, cmpOp2)
-  , (lessThanEqualsVar, cmpOp2)
-  , (greaterThanEqualsVar, cmpOp2)
-  -- sigma expressions
-  , (sigmaOrVar, monoT $ sigmaT `arr` (sigmaT `arr` sigmaT))
-  , (sigmaAndVar, monoT $ sigmaT `arr` (sigmaT `arr` sigmaT))
-  , (allSigmaVecVar, forA $ monoT $ (a `arr` sigmaT) `arr` (listT a `arr` sigmaT))
-  , (anySigmaVecVar, forA $ monoT $ (a `arr` sigmaT) `arr` (listT a `arr` sigmaT))
-  , (toSigmaVar, monoT $ boolT `arr` sigmaT)
-  -- signatures
-  , (checkSigVar, monoT $ bytesT `arr` (intT `arr` boolT))
-  , (checkMultiSigVar, monoT $ intT `arr` (listT bytesT `arr` (listT intT `arr` boolT)))
-  -- vec expressions
-  , (nilVecVar, forA $ monoT $ listT a)
-  , (consVecVar, forA $ monoT $ a `arr` (listT a `arr` listT a))
-  , (appendVecVar, forA $ monoT $ listT a `arr` (listT a `arr` listT a))
-  , (vecAtVar, forA $ monoT $ listT a `arr` (intT `arr` a))
-  , (lengthVecVar, forA $ monoT $ listT a `arr` intT)
-  , (mapVecVar, forAB $ monoT $ (a `arr` b) `arr` (listT a `arr` listT b))
-  , (filterVecVar, forAB $ monoT $ (a `arr` boolT) `arr` (listT a `arr` listT a))
-  , (foldlVecVar, forAB $ monoT $ (b `arr` (a `arr` b)) `arr` (b `arr` (listT a `arr` b)))
-  , (foldrVecVar, forAB $ monoT $ (a `arr` (b `arr` b)) `arr` (b `arr` (listT a `arr` b)))
-  , (sumVecVar, monoT $ listT intT `arr` intT)
-  , (productVecVar, monoT $ listT intT `arr` intT)
-  , (andVecVar, monoT $ listT boolT `arr` boolT)
-  , (orVecVar, monoT $ listT boolT `arr` boolT)
-  , (allVecVar, forA $ monoT $ (a `arr` boolT) `arr` (listT a `arr` boolT))
-  , (anyVecVar, forA $ monoT $ (a `arr` boolT) `arr` (listT a `arr` boolT))
-  , (andSigmaVecVar, monoT $ listT sigmaT `arr` sigmaT)
-  , (orSigmaVecVar, monoT $ listT sigmaT `arr` sigmaT)
-  , (getBoxIdVar, monoT $ boxT `arr` textT)
-  , (getBoxValueVar, monoT $ boxT `arr` intT)
-  , (getBoxPostHeightVar, monoT $ boxT `arr` intT)
-  , (getBoxScriptVar, monoT $ boxT `arr` scriptT)
-  , (undefVar, forA $ monoT a)
-  , (traceVar, forA $ monoT $ textT `arr` (a `arr` a))
-  , (heightVar, monoT intT)
-  , (inputVar, monoT $ intT `arr` boxT)
-  , (outputVar, monoT $ intT `arr` boxT)
-  , (selfVar, monoT boxT)
-  , (inputsVar, monoT $ listT boxT)
-  , (outputsVar, monoT $ listT boxT)
-  , (dataInputsVar, monoT $ listT boxT)
-  , (getVarVar, forA $ monoT $ intT `arr` a)
   , (altVar, forA $ monoT $ a `arr` (a `arr` a))
   , (failCaseVar, forA $ monoT a)
-  ] ++ tupleConVars ++ tupleAtVars ++ textExprVars ++ bytesExprVars ++ getBoxArgVars
+  -- lists
+  , (nilVecVar,  forA $ monoT $ listT a)
+  , (consVecVar, forA $ monoT $ a `arr` (listT a `arr` listT a))
+  ] ++ tupleConVars ++ tupleAtVars
   where
-    getBoxArgVars =
-      fmap (\ty -> (getBoxArgVar' ty, monoT $ boxT `arr` (listT $ argTagToType ty))) argTypes
-
     forA = forAllT noLoc "a"
-    forAB = forA . forAllT noLoc "b"
     a = varT "a"
-    b = varT "b"
     arr = arrowT
-
-    opT2 x = monoT $ x `arr` (x `arr` x)
-    boolOp2 = opT2 boolT
-    intOp2 = opT2 intT
-    cmpOp2 = forA $ monoT $ a `arr` (a `arr` boolT)
 
     tupleConVars = fmap toTuple [2..maxTupleSize]
       where
@@ -379,18 +208,6 @@ defaultContext = H.Context $ M.fromList $
 
     v n = mappend "a" (showt n)
 
-    textExprVars =
-      [ (appendTextVar, monoT $ textT `arr` (textT `arr` textT))
-      , (lengthTextVar, monoT $ textT `arr` intT)
-      , (convertToTextVar, forA $ monoT $ a `arr` textT)
-      ] ++ (fmap (\alg -> (bytesHashVar alg, monoT $ bytesT `arr` bytesT)) [Sha256])
-
-    bytesExprVars =
-      [ (appendBytesVar, monoT $ bytesT `arr` (bytesT `arr` bytesT))
-      , (lengthBytesVar, monoT $ bytesT `arr` intT)
-      ] ++ (fmap (\tag -> (serialiseToBytesVar tag, monoT $ argTagToType tag `arr` bytesT)) argTypes)
-        ++ (fmap (\tag -> (deserialiseToBytesVar tag, monoT $ bytesT `arr` argTagToType tag)) argTypes)
-
 
 intE, textE, boolE, bytesE, sigmaE :: loc -> H.Term prim loc Text
 
@@ -400,15 +217,13 @@ bytesE loc = varE loc bytesVar
 boolE loc = varE loc boolVar
 sigmaE loc = varE loc sigmaVar
 
-intVar, textVar, bytesVar, boolVar, sigmaVar, notVar, negateVar :: Text
+intVar, textVar, bytesVar, boolVar, sigmaVar :: Text
 
 intVar = secretVar "Int"
 textVar = secretVar "Text"
 bytesVar = secretVar "Bytes"
 boolVar = secretVar "Bool"
 sigmaVar = secretVar "Sigma"
-notVar = secretVar "not"
-negateVar = secretVar "negate"
 
 tupleAtVar :: Int -> Int -> Text
 tupleAtVar size n = secretVar $ mconcat ["tupleAt-", showt size, "-", showt n]
@@ -416,116 +231,18 @@ tupleAtVar size n = secretVar $ mconcat ["tupleAt-", showt size, "-", showt n]
 tupleConVar :: Int -> Text
 tupleConVar size = secretVar $ mappend "tuple" (showt size)
 
-ifVar, pkVar :: Text
+nilVecVar, consVecVar :: Text
 
+nilVecVar = secretVar "nil"
+consVecVar = secretVar "cons"
+
+ifVar :: Text
 ifVar = secretVar "if"
-pkVar = secretVar "pk"
-
-
-andVar, orVar, xorVar, plusVar, minusVar, timesVar, divVar,
-  equalsVar, notEqualsVar, lessThanVar,
-  greaterThanVar, lessThanEqualsVar, greaterThanEqualsVar :: Text
-
-andVar  = secretVar "and"
-orVar   = secretVar "or"
-xorVar   = secretVar "xor"
-plusVar = secretVar "plus"
-minusVar = secretVar "minus"
-timesVar = secretVar "times"
-divVar   = secretVar "div"
-equalsVar = secretVar "equals"
-notEqualsVar = secretVar "notEquals"
-lessThanVar  = secretVar "lessThan"
-greaterThanVar = secretVar "greaterThan"
-lessThanEqualsVar = secretVar "lessThanEquals"
-greaterThanEqualsVar = secretVar "greaterThanEquals"
-
-nilVecVar, consVecVar, appendVecVar, vecAtVar, lengthVecVar, mapVecVar, foldlVecVar, foldrVecVar, filterVecVar,
-  andSigmaVecVar, orSigmaVecVar, sumVecVar, productVecVar, andVecVar, orVecVar, allVecVar, anyVecVar,
-  allSigmaVecVar, anySigmaVecVar :: Text
-
-nilVecVar = secretVar "nilVec"
-consVecVar = secretVar "consVec"
-appendVecVar = secretVar "appendVec"
-vecAtVar = secretVar "vecAt"
-lengthVecVar = secretVar Const.length
-mapVecVar = secretVar Const.map
-foldlVecVar = secretVar Const.foldl
-foldrVecVar = secretVar Const.foldr
-andSigmaVecVar = secretVar Const.andSigma
-orSigmaVecVar = secretVar Const.orSigma
-sumVecVar = secretVar Const.sum
-productVecVar = secretVar Const.product
-orVecVar = secretVar Const.or
-andVecVar = secretVar Const.and
-filterVecVar = secretVar Const.filter
-allVecVar = secretVar Const.all
-anyVecVar = secretVar Const.any
-allSigmaVecVar = secretVar Const.allSigma
-anySigmaVecVar = secretVar Const.anySigma
-
-checkSigVar, checkMultiSigVar :: Text
-
-checkSigVar = secretVar Const.checkSig
-checkMultiSigVar = secretVar Const.checkMultiSig
-
-appendTextVar, lengthTextVar :: Text
-
-appendTextVar = secretVar "appendText"
-lengthTextVar = secretVar "lengthText"
-
-appendBytesVar :: Text
-appendBytesVar = secretVar Const.appendBytes
-
-lengthBytesVar :: Text
-lengthBytesVar = secretVar Const.lengthBytes
-
-serialiseToBytesVar, deserialiseToBytesVar :: ArgType -> Text
-
-serialiseToBytesVar   tag = secretVar $ Const.serialiseBytes (argTypeName tag)
-deserialiseToBytesVar tag = secretVar $ Const.deserialiseBytes (argTypeName tag)
-
-convertToTextVar :: Text
-convertToTextVar = secretVar "show"
-
-bytesHashVar :: HashAlgo -> Text
-bytesHashVar hashAlgo = secretVar $ mappend "bytesHash" (showt hashAlgo)
-
-
-getBoxIdVar, getBoxValueVar, getBoxScriptVar, getBoxPostHeightVar :: Text
-
-getBoxIdVar = secretVar Const.getBoxId
-getBoxValueVar = secretVar Const.getBoxValue
-getBoxScriptVar = secretVar Const.getBoxScript
-getBoxPostHeightVar = secretVar Const.getBoxPostHeight
-
-undefVar :: Text
-undefVar = secretVar "undefined"
-
-traceVar :: Text
-traceVar = secretVar "trace"
-
-heightVar, inputVar, outputVar, selfVar, inputsVar, outputsVar, dataInputsVar, getVarVar :: Text
-
-heightVar = secretVar "height"
-inputVar = secretVar "input"
-outputVar = secretVar "output"
-selfVar = secretVar "self"
-inputsVar = secretVar "inputs"
-outputsVar = secretVar "outputs"
-dataInputsVar = secretVar "dataInputs"
-getVarVar = secretVar "getVar"
 
 altVar, failCaseVar :: Text
 
 altVar = secretVar "altCases"
 failCaseVar = secretVar "failCase"
-
-sigmaAndVar, sigmaOrVar, toSigmaVar :: Text
-
-sigmaAndVar = secretVar Const.sigmaAnd
-sigmaOrVar  = secretVar Const.sigmaOr
-toSigmaVar  = secretVar Const.toSigma
 
 ---------------------------------------------------------
 
@@ -597,6 +314,63 @@ selectorNameVar cons n = secretVar $ mconcat ["sel_", consName'name cons, "_", s
 recordUpdateVar :: VarName -> Text
 recordUpdateVar field = secretVar $ mconcat ["update_", varName'name field]
 
-getBoxArgVar' :: ArgType -> Text
-getBoxArgVar' = secretVar . getBoxArgVar
+------------------------------------------------------------
+--
+
+
+caseToLet :: MonadLang m =>
+  (ConsName -> Int -> Text) -> Loc -> Lang -> [CaseExpr Lang] -> m Lang
+caseToLet toSelectorName loc expr cases = do
+  v <- getFreshVar loc
+  fmap (Fix . Let loc [simpleBind v expr]) $ caseToLet' toSelectorName loc v cases
+
+caseToLet' :: MonadLang m =>
+  (ConsName -> Int -> Text) -> Loc -> VarName -> [CaseExpr Lang] -> m Lang
+caseToLet' toSelectorName topLoc var cases = fmap (foldr (\(loc, a) rest -> Fix $ AltE loc a rest) failCase) $ mapM fromCase cases
+  where
+    toVarExpr loc v = Fix $ Var loc $ VarName loc $ varName'name v
+
+    fromCase CaseExpr{..} = fmap (H.getLoc caseExpr'lhs, ) $ case caseExpr'lhs of
+      PVar ploc pvar -> return $ Fix $ Let ploc [simpleBind pvar $ toVarExpr ploc var] caseExpr'rhs
+      PWildCard _ -> return $ caseExpr'rhs
+      PPrim ploc p -> return $ Fix $ If ploc (eqPrim ploc var p) caseExpr'rhs failCase
+      PCons ploc cons pats ->
+        case pats of
+          [] -> constCons ploc cons
+          _  -> argCons ploc cons pats
+      PTuple ploc pats -> do
+        (vs, rhs') <- reduceSubPats pats caseExpr'rhs
+        let size = length vs
+            bg = zipWith (\n v -> simpleBind v (tupleAt (varName'loc v) size n $ toVarExpr ploc var)) [0..] vs
+        return $ Fix $ Let ploc bg rhs'
+      where
+        tupleAt :: Loc -> Int -> Int -> Fix E -> Lang
+        tupleAt loc size n e = Fix $ Apply loc (Fix $ Var loc $ VarName loc $ tupleAtVar size n) e
+
+        constCons ploc cons = return $
+          D.app2 (Fix $ Var ploc $ VarName ploc $ toSelectorName cons 0) (toVarExpr ploc var) caseExpr'rhs
+
+        argCons ploc cons pats = do
+          (vs, rhs') <- reduceSubPats pats caseExpr'rhs
+          let bg = zipWith (\n v -> simpleBind v (Fix $ Apply (varName'loc v) (selector ploc cons n) $ toVarExpr ploc var)) [0..] vs
+          return $ Fix $ Let ploc bg rhs'
+
+    selector ploc cons n = Fix $ Var ploc (VarName ploc (toSelectorName cons n))
+
+    failCase = Fix $ FailCase topLoc
+
+    eqPrim ploc v p = Fix $ InfixApply ploc (toVarExpr ploc v) (VarName ploc Const.equals) (Fix $ PrimE ploc p)
+
+reduceSubPats :: forall m . MonadLang m => [Pat] -> Lang -> m ([VarName], Lang)
+reduceSubPats pats rhs = runStateT (mapM go pats) rhs
+  where
+    go :: Pat -> StateT Lang m VarName
+    go pat = case pat of
+      PVar _ var -> return var
+      _          -> do
+        expr <- get
+        let loc = H.getLoc pat
+        var  <- lift $ getFreshVar loc
+        put $ Fix $ CaseOf loc (Fix $ Var loc var) $ [CaseExpr pat expr]
+        return var
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Lib/Base.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Lib/Base.hs
@@ -1,211 +1,84 @@
 module Hschain.Utxo.Lang.Lib.Base(
-    importBase
-  , baseNames
+    baseNames
   , baseLibTypeContext
-  , baseLibExecContext
+  , baseLibExecCtx
+  , baseLibInferCtx
+{-    importBase
   , langTypeContext
   , baseModuleCtx
   , baseFuns
+-}
 ) where
 
+import Prelude ((.), fmap, ($), Monoid(..))
 import qualified Prelude as P
-import Prelude ((.))
-import Prelude (($))
-
-import Data.Either
-import Data.Text (Text)
 
 import Data.Fix hiding ((~>))
-import Hschain.Utxo.Lang.Desugar
+import Data.Text (Text)
+
 import Hschain.Utxo.Lang.Expr
-import Hschain.Utxo.Lang.Types (ArgType(..),argTypes)
-import Hschain.Utxo.Lang.Monad
-import Hschain.Utxo.Lang.Infer
-
+import Hschain.Utxo.Lang.Types (argTypes)
 import Language.HM (monoT, forAllT)
-import qualified Language.HM as H
-
-import qualified Data.Map as M
 
 import qualified Hschain.Utxo.Lang.Const as Const
+import qualified Data.Map as M
+import qualified Language.HM as H
 
 infixr 6 ~>
 
-baseModuleCtx :: ModuleCtx
-baseModuleCtx = ModuleCtx
-  { moduleCtx'types = InferCtx baseLibTypeContext P.mempty
-  , moduleCtx'exprs = baseLibExecContext
+-- | Defines prelude functions.
+-- Note that we only need to define those functions that are combinations of primitive functions.
+-- The primitive functions are substituted for primOps on later stage of compilation.
+baseLibExecCtx :: ExecCtx
+baseLibExecCtx = ExecCtx
+  { execCtx'vars = M.fromList $
+      [ bind "id"           (lam' ["x"] vx)
+      , bind "const"        (lam' ["x", "y"] $ vx)
+      , bind "."            (lam' ["f", "g", "x"] (ap1 "f" (ap1 "g" (var' "x"))))
+      , bind "getInput"     (lam' ["x"] $ ap2 Const.listAt (var' Const.getInputs) vx)
+      , bind "getOutput"    (lam' ["x"] $ ap2 Const.listAt (var' Const.getOutputs) vx)
+      , bind "getDataInput" (lam' ["x"] $ ap2 Const.listAt (var' Const.getDataInputs) vx)
+      , bind "otherwise"    (Fix $ PrimE noLoc $ PrimBool P.True)
+      , bind "fst"          (lamPair $ var' "a")
+      , bind "snd"          (lamPair $ var' "b")
+      ] P.++ sigCmps
+  }
+  where
+    sigCmps = fmap (\(a, b) -> bind a (lam' ["x", "y"] $ toSig $ op2 b vx vy))
+      [ (Const.sigmaEquals, Const.equals)
+      , (Const.sigmaNonEquals, Const.nonEquals)
+      , (Const.sigmaLess, Const.less)
+      , (Const.sigmaGreater, Const.greater)
+      , (Const.sigmaLessEquals, Const.lessEquals)
+      , (Const.sigmaGreaterEquals, Const.greaterEquals)
+      ]
+
+    lamPair e = Fix $ Lam noLoc (PTuple noLoc [PVar noLoc "a", PVar noLoc "b"]) e
+
+    toSig = ap1 "toSigma"
+    ap1 name e = Fix $ Apply noLoc (var' name) e
+    ap2 name a b = Fix $ Apply noLoc (ap1 name a) b
+    op2 name a b = Fix $ InfixApply noLoc a (VarName noLoc name) b
+    var' name = Fix $ Var noLoc (VarName noLoc name)
+
+    vx = var' "x"
+    vy = var' "y"
+
+    lam' names expr = case names of
+      []     -> expr
+      [name] -> Fix $ Lam noLoc (PVar noLoc $ VarName noLoc name) expr
+      _      -> Fix $ LamList noLoc (fmap (PVar noLoc . VarName noLoc) names) expr
+
+    bind var body = (VarName noLoc var, body)
+
+baseLibInferCtx :: InferCtx
+baseLibInferCtx = InferCtx
+  { inferCtx'binds = baseLibTypeContext
+  , inferCtx'types = mempty
   }
 
-langTypeContext :: TypeContext
-langTypeContext = baseLibTypeContext
-
--- | Prelude functions
-importBase :: Lang -> Lang
-importBase = bindGroupToLet baseFuns
-
-baseLibExecContext :: ExecCtx
-baseLibExecContext =
-  fromRight err $ runInferM $ fmap ((\vars -> ExecCtx vars) . M.fromList) $ P.mapM fromBindToExec baseFuns
-  where
-    fromBindToExec Bind{..} = fmap (bind'name, ) $ altGroupToExpr bind'alts
-    err = P.error "Failed to load base module"
-
-baseFuns :: [Bind Lang]
-baseFuns =
-  [ all
-  , any
-  , andSigma
-  , orSigma
-  , and
-  , or
-  , sum
-  , product
-  , id
-  , const
-  , compose
-  , getHeight
-  , getSelf
-  , getOutput
-  , getInput
-  , getOutputs
-  , getInputs
-  , getDataInputs
-  , getBoxId
-  , getBoxValue
-  , getBoxScript
-  , getBoxPostHeight
-  , sha256
-  , lengthVec
-  , lengthText
-  , lengthBytes
-  , show
-  , plus
-  , times
-  , minus
-  , division
-  , appendText
-  , appendBytes
-  , appendVec
-  , mapVec
-  , foldlVec
-  , foldrVec
-  , filterVec
-  , pk
-  , toSigma
-  , sigmaAnd
-  , sigmaOr
-  , sigmaLess
-  , sigmaLessEquals
-  , sigmaGreater
-  , sigmaGreaterEquals
-  , sigmaEquals
-  , sigmaNonEquals
-  , allSigma
-  , anySigma
-  , atVec
-  , andB
-  , orB
-  , xorB
-  , notB
-  , eq
-  , neq
-  , lt
-  , gt
-  , lteq
-  , gteq
-  , fst
-  , snd
-  , otherwise
-  , undefined
-  , checkSig
-  , checkMultiSig
-  ] P.++ getBoxArgListFuns P.++ getVars P.++ serialiseVars P.++ deserialiseVars
-  where
-    getBoxArgListFuns = fmap getBoxArgList argTypes
-    getVars = fmap getVarBy argTypes
-    serialiseVars = fmap serialiseVarBy argTypes
-    deserialiseVars = fmap deserialiseVarBy argTypes
-
 baseNames :: [Text]
-baseNames =
-  [ Const.all
-  , Const.any
-  , "and"
-  , "or"
-  , Const.andSigma
-  , Const.orSigma
-  , "sum"
-  , "product"
-  , "id"
-  , "const"
-  , "."
-  , "getHeight"
-  , "getSelf"
-  , "getOutput"
-  , "getInput"
-  , "getOutputs"
-  , "getInputs"
-  , "getDataInputs"
-  , "getBoxId"
-  , "getBoxValue"
-  , "getBoxScript"
-  , "getBoxPostHeight"
-  , "getBoxArg"
-  , "sha256"
-  , "blake2b256"
-  , "length"
-  , "lengthText"
-  , "lengthBytes"
-  , "show"
-  , "+"
-  , "*"
-  , "-"
-  , "/"
-  , "<>"
-  , Const.appendBytes
-  , Const.appendList
-  , Const.foldl
-  , Const.foldr
-  , Const.filter
-  , Const.map
-  , Const.length
-  , Const.pk
-  , Const.toSigma
-  , Const.sigmaAnd
-  , Const.sigmaOr
-  , Const.listAt
-  , "&&"
-  , "||"
-  , "^^"
-  , "not"
-  , Const.equals
-  , Const.nonEquals
-  , Const.less
-  , Const.greater
-  , Const.lessEquals
-  , Const.greaterEquals
-  , "fst"
-  , "snd"
-  , Const.sigmaGreater
-  , Const.sigmaLess
-  , Const.sigmaGreaterEquals
-  , Const.sigmaLessEquals
-  , Const.sigmaEquals
-  , Const.sigmaNonEquals
-  , "otherwise"
-  , "undefined"
-  , Const.checkSig
-  , Const.checkMultiSig
-  ] P.++ getVarNames
-    P.++ getBoxArgNames
-    P.++ serialiseNames
-    P.++ deserialiseNames
-  where
-    getVarNames = fmap getEnvVarName argTypes
-    getBoxArgNames = fmap (Const.getBoxArgs . argTypeName) argTypes
-    serialiseNames = fmap (Const.serialiseBytes . argTypeName) argTypes
-    deserialiseNames = fmap (Const.deserialiseBytes . argTypeName) argTypes
+baseNames = M.keys $ H.unContext $ baseLibTypeContext
 
 (~>) :: Type -> Type -> Type
 (~>) a b = H.arrowT noLoc a b
@@ -213,80 +86,80 @@ baseNames =
 forAllT' :: Text -> Signature -> Signature
 forAllT' = forAllT noLoc
 
-assumpType :: Text -> Signature -> (Text, Signature)
-assumpType idx ty = (idx, ty)
+assumeType :: Text -> Signature -> (Text, Signature)
+assumeType idx ty = (idx, ty)
 
 baseLibTypeContext :: TypeContext
 baseLibTypeContext = H.Context $ M.fromList $
-  [ assumpType "and" (monoT $ listT boolT ~> boolT)
-  , assumpType "or" (monoT $ listT boolT ~> boolT)
-  , assumpType "andSigma" (monoT $ listT sigmaT ~> sigmaT)
-  , assumpType "orSigma" (monoT $ listT sigmaT ~> sigmaT)
-  , assumpType Const.allSigma (forA $ (aT ~> sigmaT) ~> listT aT ~> sigmaT)
-  , assumpType Const.anySigma (forA $ (aT ~> sigmaT) ~> listT aT ~> sigmaT)
-  , assumpType Const.all (forA $ (aT ~> boolT) ~> listT aT ~> boolT)
-  , assumpType Const.any (forA $ (aT ~> boolT) ~> listT aT ~> boolT)
-  , assumpType Const.sum      (monoT $ listT intT ~> intT)
-  , assumpType Const.product  (monoT $ listT intT ~> intT)
-  , assumpType  "."  (forABC $ (bT ~> cT) ~> (aT ~> bT) ~> (aT ~> cT))
-  , assumpType  "id"  (forA $ aT ~> aT)
-  , assumpType "const" (forAB $ aT ~> bT ~> aT)
-  , assumpType "getHeight" (monoT intT)
-  , assumpType "getSelf" (monoT boxT)
-  , assumpType "getOutput" (monoT $ intT ~> boxT)
-  , assumpType "getInput"  (monoT $ intT ~> boxT)
-  , assumpType "getOutputs" (monoT $ listT boxT)
-  , assumpType "getInputs" (monoT $ listT boxT)
-  , assumpType "getDataInputs" (monoT $ listT boxT)
-  , assumpType "getBoxId" (monoT $ boxT ~> textT)
-  , assumpType "getBoxValue" (monoT $ boxT ~> intT)
-  , assumpType "getBoxPostHeight" (monoT $ boxT ~> intT)
-  , assumpType "getBoxScript" (monoT $ boxT ~> bytesT)
-  , assumpType "sha256" (monoT $ bytesT ~> bytesT)
-  , assumpType "getVar" (forA $ textT ~> aT)
-  , assumpType "length" (forA $ listT aT ~> intT)
-  , assumpType "lengthText" (monoT $ textT ~> intT)
-  , assumpType "lengthBytes" (monoT $ bytesT ~> intT)
-  , assumpType "show" (forA $ aT ~> textT)
-  , assumpType "not" (monoT $ boolT ~> boolT)
-  , assumpType "&&" (monoT $ boolT ~> boolT ~> boolT)
-  , assumpType "||" (monoT $ boolT ~> boolT ~> boolT)
-  , assumpType "^^" (monoT $ boolT ~> boolT ~> boolT)
-  , assumpType Const.sigmaAnd (monoT $ sigmaT ~> sigmaT ~> sigmaT)
-  , assumpType Const.sigmaOr (monoT $ sigmaT ~> sigmaT ~> sigmaT)
-  , assumpType "pk" (monoT $ bytesT ~> sigmaT)
-  , assumpType "toSigma" (monoT $ boolT ~> sigmaT)
-  , assumpType "+" (monoT $ intT ~> intT ~> intT)
-  , assumpType "-" (monoT $ intT ~> intT ~> intT)
-  , assumpType "*" (monoT $ intT ~> intT ~> intT)
-  , assumpType "/" (monoT $ intT ~> intT ~> intT)
-  , assumpType "++" (forA $ listT aT ~> listT aT ~> listT aT)
-  , assumpType "<>" (monoT $ textT ~> textT ~> textT)
-  , assumpType Const.appendBytes (monoT $ bytesT ~> bytesT ~> bytesT)
-  , assumpType Const.filter (forAB $ (aT ~> boolT) ~> listT aT ~> listT aT)
-  , assumpType Const.map (forAB $ (aT ~> bT) ~> listT aT ~> listT bT)
-  , assumpType Const.foldl (forAB $ (aT ~> bT ~> aT) ~> aT ~> listT bT ~> aT)
-  , assumpType Const.foldr (forAB $ (aT ~> bT ~> bT) ~> bT ~> listT aT ~> bT)
-  , assumpType Const.length (forA $ listT aT ~> intT)
-  , assumpType Const.listAt (forA $ listT aT ~> intT ~> aT)
-  , assumpType "==" (forA $ aT ~> aT ~> boolT)
-  , assumpType "/=" (forA $ aT ~> aT ~> boolT)
-  , assumpType "<" (forA $ aT ~> aT ~> boolT)
-  , assumpType "<=" (forA $ aT ~> aT ~> boolT)
-  , assumpType ">=" (forA $ aT ~> aT ~> boolT)
-  , assumpType ">" (forA $ aT ~> aT ~> boolT)
-  , assumpType Const.sigmaEquals (forA $ aT ~> aT ~> sigmaT)
-  , assumpType Const.sigmaNonEquals (forA $ aT ~> aT ~> sigmaT)
-  , assumpType Const.sigmaLess (forA $ aT ~> aT ~> sigmaT)
-  , assumpType Const.sigmaLessEquals (forA $ aT ~> aT ~> sigmaT)
-  , assumpType Const.sigmaGreater (forA $ aT ~> aT ~> sigmaT)
-  , assumpType Const.sigmaGreaterEquals (forA $ aT ~> aT ~> sigmaT)
-  , assumpType "fst" (forAB $ tupleT [aT, bT] ~> aT)
-  , assumpType "snd" (forAB $ tupleT [aT, bT] ~> bT)
-  , assumpType "otherwise" (monoT boolT)
-  , assumpType "undefined" $ forA aT
-  , assumpType Const.checkSig $ monoT $ bytesT ~> intT ~> boolT
-  , assumpType Const.checkMultiSig $ monoT $ intT ~> listT bytesT ~> listT intT ~> boolT
+  [ assumeType "and" (monoT $ listT boolT ~> boolT)
+  , assumeType "or" (monoT $ listT boolT ~> boolT)
+  , assumeType "andSigma" (monoT $ listT sigmaT ~> sigmaT)
+  , assumeType "orSigma" (monoT $ listT sigmaT ~> sigmaT)
+  , assumeType Const.allSigma (forA $ (aT ~> sigmaT) ~> listT aT ~> sigmaT)
+  , assumeType Const.anySigma (forA $ (aT ~> sigmaT) ~> listT aT ~> sigmaT)
+  , assumeType Const.all (forA $ (aT ~> boolT) ~> listT aT ~> boolT)
+  , assumeType Const.any (forA $ (aT ~> boolT) ~> listT aT ~> boolT)
+  , assumeType Const.sum      (monoT $ listT intT ~> intT)
+  , assumeType Const.product  (monoT $ listT intT ~> intT)
+  , assumeType  "."  (forABC $ (bT ~> cT) ~> (aT ~> bT) ~> (aT ~> cT))
+  , assumeType  "id"  (forA $ aT ~> aT)
+  , assumeType "const" (forAB $ aT ~> bT ~> aT)
+  , assumeType "getHeight" (monoT intT)
+  , assumeType "getSelf" (monoT boxT)
+  , assumeType "getOutput" (monoT $ intT ~> boxT)
+  , assumeType "getInput"  (monoT $ intT ~> boxT)
+  , assumeType "getOutputs" (monoT $ listT boxT)
+  , assumeType "getInputs" (monoT $ listT boxT)
+  , assumeType "getDataInputs" (monoT $ listT boxT)
+  , assumeType "getBoxId" (monoT $ boxT ~> textT)
+  , assumeType "getBoxValue" (monoT $ boxT ~> intT)
+  , assumeType "getBoxPostHeight" (monoT $ boxT ~> intT)
+  , assumeType "getBoxScript" (monoT $ boxT ~> bytesT)
+  , assumeType "sha256" (monoT $ bytesT ~> bytesT)
+  , assumeType "getVar" (forA $ textT ~> aT)
+  , assumeType "length" (forA $ listT aT ~> intT)
+  , assumeType "lengthText" (monoT $ textT ~> intT)
+  , assumeType "lengthBytes" (monoT $ bytesT ~> intT)
+  , assumeType "show" (forA $ aT ~> textT)
+  , assumeType "not" (monoT $ boolT ~> boolT)
+  , assumeType "&&" (monoT $ boolT ~> boolT ~> boolT)
+  , assumeType "||" (monoT $ boolT ~> boolT ~> boolT)
+  , assumeType Const.sigmaAnd (monoT $ sigmaT ~> sigmaT ~> sigmaT)
+  , assumeType Const.sigmaOr (monoT $ sigmaT ~> sigmaT ~> sigmaT)
+  , assumeType "pk" (monoT $ bytesT ~> sigmaT)
+  , assumeType "toSigma" (monoT $ boolT ~> sigmaT)
+  , assumeType "+" (monoT $ intT ~> intT ~> intT)
+  , assumeType "-" (monoT $ intT ~> intT ~> intT)
+  , assumeType "negate" (monoT $ intT ~> intT)
+  , assumeType "*" (monoT $ intT ~> intT ~> intT)
+  , assumeType "/" (monoT $ intT ~> intT ~> intT)
+  , assumeType "++" (forA $ listT aT ~> listT aT ~> listT aT)
+  , assumeType "<>" (monoT $ textT ~> textT ~> textT)
+  , assumeType Const.appendBytes (monoT $ bytesT ~> bytesT ~> bytesT)
+  , assumeType Const.filter (forAB $ (aT ~> boolT) ~> listT aT ~> listT aT)
+  , assumeType Const.map (forAB $ (aT ~> bT) ~> listT aT ~> listT bT)
+  , assumeType Const.foldl (forAB $ (aT ~> bT ~> aT) ~> aT ~> listT bT ~> aT)
+  , assumeType Const.foldr (forAB $ (aT ~> bT ~> bT) ~> bT ~> listT aT ~> bT)
+  , assumeType Const.length (forA $ listT aT ~> intT)
+  , assumeType Const.listAt (forA $ listT aT ~> intT ~> aT)
+  , assumeType "==" (forA $ aT ~> aT ~> boolT)
+  , assumeType "/=" (forA $ aT ~> aT ~> boolT)
+  , assumeType "<" (forA $ aT ~> aT ~> boolT)
+  , assumeType "<=" (forA $ aT ~> aT ~> boolT)
+  , assumeType ">=" (forA $ aT ~> aT ~> boolT)
+  , assumeType ">" (forA $ aT ~> aT ~> boolT)
+  , assumeType Const.sigmaEquals (forA $ aT ~> aT ~> sigmaT)
+  , assumeType Const.sigmaNonEquals (forA $ aT ~> aT ~> sigmaT)
+  , assumeType Const.sigmaLess (forA $ aT ~> aT ~> sigmaT)
+  , assumeType Const.sigmaLessEquals (forA $ aT ~> aT ~> sigmaT)
+  , assumeType Const.sigmaGreater (forA $ aT ~> aT ~> sigmaT)
+  , assumeType Const.sigmaGreaterEquals (forA $ aT ~> aT ~> sigmaT)
+  , assumeType "fst" (forAB $ tupleT [aT, bT] ~> aT)
+  , assumeType "snd" (forAB $ tupleT [aT, bT] ~> bT)
+  , assumeType "otherwise" (monoT boolT)
+  , assumeType "undefined" $ forA aT
+  , assumeType Const.checkSig $ monoT $ bytesT ~> intT ~> boolT
+  , assumeType Const.checkMultiSig $ monoT $ intT ~> listT bytesT ~> listT intT ~> boolT
   ] P.++ getBoxArgListTypes P.++ getEnvVarTypes P.++ serialiseTypes P.++ deserialiseTypes
   where
     forA = forAllT' "a" . monoT
@@ -294,256 +167,19 @@ baseLibTypeContext = H.Context $ M.fromList $
     forABC = forAllT' "a" . forAllT' "b" . forAllT' "c" . monoT
 
     getBoxArgListTypes =
-      fmap (\ty -> assumpType (getBoxArgVar ty) (monoT $ boxT ~> listT (argTagToType ty))) argTypes
+      fmap (\ty -> assumeType (getBoxArgVar ty) (monoT $ boxT ~> listT (argTagToType ty))) argTypes
 
     getEnvVarTypes =
-      fmap (\ty -> assumpType (getEnvVarName ty) (monoT $ listT (argTagToType ty))) argTypes
+      fmap (\ty -> assumeType (getEnvVarName ty) (monoT $ listT (argTagToType ty))) argTypes
 
     serialiseTypes =
-      fmap (\ty -> assumpType (Const.serialiseBytes $ argTypeName ty) (monoT $ argTagToType ty ~> bytesT)) argTypes
+      fmap (\ty -> assumeType (Const.serialiseBytes $ argTypeName ty) (monoT $ argTagToType ty ~> bytesT)) argTypes
 
     deserialiseTypes =
-      fmap (\ty -> assumpType (Const.deserialiseBytes $ argTypeName ty) (monoT $ bytesT ~> argTagToType ty)) argTypes
-
-all :: Bind Lang
-all = bind Const.all (Fix $ LamList noLoc ["f", "xs"] $ Fix $ Apply noLoc (Fix $ Apply noLoc (Fix $ VecE noLoc $ VecAll noLoc) f) $ var' "xs")
-
-any :: Bind Lang
-any = bind Const.any (Fix $ LamList noLoc ["f", "xs"] $ Fix $ Apply noLoc (Fix $ Apply noLoc (Fix $ VecE noLoc $ VecAny noLoc) f) $ var' "xs")
-
-and :: Bind Lang
-and = bind "and" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecAnd noLoc) x)
-
-or :: Bind Lang
-or = bind "or" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecOr noLoc) x)
-
-andSigma :: Bind Lang
-andSigma = bind "andSigma" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecAndSigma noLoc) x)
-
-orSigma :: Bind Lang
-orSigma = bind "orSigma" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecOrSigma noLoc) x)
-
-sum :: Bind Lang
-sum = bind Const.sum (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecSum noLoc) x)
-
-product :: Bind Lang
-product = bind Const.product (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc $ VecProduct noLoc) x)
-
-id :: Bind Lang
-id = bind "id" $ Fix $ Lam noLoc "x" $ Fix $ Var noLoc "x"
-
-const :: Bind Lang
-const = bind "const" (Fix $ Lam noLoc "x" $ Fix $ Lam noLoc "y" $ Fix $ Var noLoc "x")
-
-compose :: Bind Lang
-compose = bind "." (Fix $ LamList noLoc ["f", "g", "x"] (Fix $ Apply noLoc (var' "f") (Fix $ Apply noLoc (var' "g") (var' "x"))))
-
-getHeight :: Bind Lang
-getHeight = bind "getHeight" (Fix $ GetEnv noLoc (Height noLoc))
-
-getSelf :: Bind Lang
-getSelf = bind "getSelf" (Fix $ GetEnv noLoc (Self noLoc))
-
-getOutput :: Bind Lang
-getOutput = bind "getOutput" (Fix $ Lam noLoc "x" $ Fix $ GetEnv noLoc $ Output noLoc $ Fix $ Var noLoc "x")
-
-getInput :: Bind Lang
-getInput = bind "getInput" (Fix $ Lam noLoc "x" $ Fix $ GetEnv noLoc $ Input noLoc $ Fix $ Var noLoc "x")
-
-getOutputs :: Bind Lang
-getOutputs = bind "getOutputs" (Fix $ GetEnv noLoc $ Outputs noLoc)
-
-getInputs :: Bind Lang
-getInputs = bind "getInputs" (Fix $ GetEnv noLoc $ Inputs noLoc)
-
-getDataInputs :: Bind Lang
-getDataInputs = bind "getDataInputs" (Fix $ GetEnv noLoc $ DataInputs noLoc)
-
-getBoxId :: Bind Lang
-getBoxId = bind "getBoxId" (Fix $ Lam noLoc "x" $ Fix $ BoxE noLoc $ BoxAt noLoc (Fix $ Var noLoc "x") BoxFieldId)
-
-getBoxValue :: Bind Lang
-getBoxValue = bind "getBoxValue" (Fix $ Lam noLoc "x" $ Fix $ BoxE noLoc $ BoxAt noLoc (Fix $ Var noLoc "x") BoxFieldValue)
-
-getBoxScript :: Bind Lang
-getBoxScript = bind "getBoxScript" (Fix $ Lam noLoc "x" $ Fix $ BoxE noLoc $ BoxAt noLoc (Fix $ Var noLoc "x") BoxFieldScript)
-
-getBoxPostHeight :: Bind Lang
-getBoxPostHeight = bind "getBoxPostHeight" (Fix $ Lam noLoc "x" $ Fix $ BoxE noLoc $ BoxAt noLoc (Fix $ Var noLoc "x") BoxFieldPostHeight)
-
-getBoxArgList :: ArgType -> Bind Lang
-getBoxArgList ty = bind (getBoxArgVar ty) (Fix $ Lam noLoc "box" $ Fix $ BoxE noLoc $ BoxAt noLoc (Fix $ Var noLoc "box") (BoxFieldArgList ty))
-
-sha256 :: Bind Lang
-sha256 = bind "sha256" (Fix $ Lam noLoc "x" $ Fix $ BytesE noLoc $ BytesHash noLoc Sha256 (Fix $ Var noLoc "x"))
-
-getVarBy :: ArgType -> Bind Lang
-getVarBy ty = bind (getEnvVarName ty) (Fix $ GetEnv noLoc $ GetVar noLoc ty)
-
-serialiseVarBy :: ArgType -> Bind Lang
-serialiseVarBy ty = bind (Const.serialiseBytes $ argTypeName ty) (Fix $ Lam noLoc "x" $ Fix $ BytesE noLoc $ SerialiseToBytes noLoc ty $ Fix $ Var noLoc "x")
-
-deserialiseVarBy :: ArgType -> Bind Lang
-deserialiseVarBy ty = bind (Const.deserialiseBytes $ argTypeName ty) (Fix $ Lam noLoc "x" $ Fix $ BytesE noLoc $ DeserialiseFromBytes noLoc ty $ Fix $ Var noLoc "x")
-
-show :: Bind Lang
-show = bind "show" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ TextE noLoc (ConvertToText noLoc)) (Fix $ Var noLoc "x"))
-
-lengthVec :: Bind Lang
-lengthVec = bind "length" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ VecE noLoc (VecLength noLoc)) (Fix $ Var noLoc "x"))
-
-lengthText :: Bind Lang
-lengthText = bind "lengthText" (Fix $ Lam noLoc "x" $ Fix $ Apply noLoc (Fix $ TextE noLoc (TextLength noLoc)) (Fix $ Var noLoc "x"))
-
-lengthBytes :: Bind Lang
-lengthBytes = bind "lengthBytes" (Fix $ Lam noLoc "x" $ Fix $ BytesE noLoc $ BytesLength noLoc x)
-
-biOp :: Text -> BinOp -> Bind Lang
-biOp name op = bind name (Fix $ LamList noLoc ["x", "y"] $ Fix $ BinOpE noLoc op x y)
-
-sigmaBiOp :: Text -> BinOp -> Bind Lang
-sigmaBiOp name op = bind name (Fix $ LamList noLoc ["x", "y"] $ Fix $ SigmaE noLoc $ SPrimBool noLoc $ Fix $ BinOpE noLoc op x y)
-
-unOp :: Text -> UnOp -> Bind Lang
-unOp name op = bind name (Fix $ Lam noLoc "x" $ Fix $ UnOpE noLoc op x)
-
-eq :: Bind Lang
-eq = biOp "==" Equals
-
-neq :: Bind Lang
-neq = biOp "/=" NotEquals
-
-sigmaLess :: Bind Lang
-sigmaLess = sigmaBiOp Const.sigmaLess LessThan
-
-sigmaLessEquals :: Bind Lang
-sigmaLessEquals = sigmaBiOp Const.sigmaLessEquals LessThanEquals
-
-sigmaGreater :: Bind Lang
-sigmaGreater = sigmaBiOp Const.sigmaGreater GreaterThan
-
-sigmaGreaterEquals :: Bind Lang
-sigmaGreaterEquals = sigmaBiOp Const.sigmaGreaterEquals GreaterThanEquals
-
-sigmaEquals :: Bind Lang
-sigmaEquals = sigmaBiOp Const.sigmaEquals Equals
-
-sigmaNonEquals :: Bind Lang
-sigmaNonEquals = sigmaBiOp Const.sigmaEquals NotEquals
-
-lt :: Bind Lang
-lt = biOp "<" LessThan
-
-lteq :: Bind Lang
-lteq = biOp "<=" LessThanEquals
-
-gt :: Bind Lang
-gt = biOp ">" GreaterThan
-
-gteq :: Bind Lang
-gteq = biOp ">=" GreaterThanEquals
-
-
-andB :: Bind Lang
-andB = biOp "&&" And
-
-orB :: Bind Lang
-orB = biOp "||" Or
-
-xorB :: Bind Lang
-xorB = biOp "^^" And
-
-notB :: Bind Lang
-notB = unOp "not" Not
-
-plus :: Bind Lang
-plus = biOp "+" Plus
-
-times :: Bind Lang
-times = biOp "*" Times
-
-minus :: Bind Lang
-minus = biOp "-" Minus
-
-division :: Bind Lang
-division = biOp "/" Div
-
-sigmaAnd :: Bind Lang
-sigmaAnd = bind Const.sigmaAnd (Fix $ LamList noLoc ["x", "y"] $ Fix $ SigmaE noLoc $ SAnd noLoc x y)
-
-sigmaOr :: Bind Lang
-sigmaOr = bind Const.sigmaOr (Fix $ LamList noLoc ["x", "y"] $ Fix $ SigmaE noLoc $ SOr noLoc x y)
-
-allSigma :: Bind Lang
-allSigma = bind Const.allSigma (Fix $ LamList noLoc ["x", "y"] $ app2 (Fix $ VecE noLoc $ VecAllSigma noLoc) x y)
-
-anySigma :: Bind Lang
-anySigma = bind Const.anySigma (Fix $ LamList noLoc ["x", "y"] $ app2 (Fix $ VecE noLoc $ VecAnySigma noLoc) x y)
-
-toSigma :: Bind Lang
-toSigma = bind "toSigma" (Fix $ Lam noLoc "x" $ Fix $ SigmaE noLoc $ SPrimBool noLoc x)
-
-pk :: Bind Lang
-pk = bind Const.pk (Fix $ Lam noLoc "x" $ Fix $ SigmaE noLoc $ Pk noLoc x)
-
-mapVec :: Bind Lang
-mapVec = bind Const.map (Fix $ LamList noLoc ["f", "x"] $ app2 (Fix $ VecE noLoc (VecMap noLoc)) f x)
-
-filterVec :: Bind Lang
-filterVec = bind Const.filter (Fix $ LamList noLoc ["f", "x"] $ app2 (Fix $ VecE noLoc (VecFilter noLoc)) f x)
-
-foldlVec :: Bind Lang
-foldlVec = bind Const.foldl (Fix $ LamList noLoc ["f", "x", "y"] $ app3 (Fix $ VecE noLoc (VecFoldl noLoc)) f x y)
-
-foldrVec :: Bind Lang
-foldrVec = bind Const.foldr (Fix $ LamList noLoc ["f", "x", "y"] $ app3 (Fix $ VecE noLoc (VecFoldr noLoc)) f x y)
-
-appendVec :: Bind Lang
-appendVec = bind Const.appendList (Fix $ LamList noLoc ["x", "y"] $ Fix $ VecE noLoc $ VecAppend noLoc x y)
-
-checkSig :: Bind Lang
-checkSig = bind Const.checkSig (Fix $ LamList noLoc ["pubKey", "sigIndex"] $ Fix $ CheckSig noLoc (var' "pubKey") (var' "sigIndex"))
-
-checkMultiSig :: Bind Lang
-checkMultiSig = bind Const.checkMultiSig (Fix $ LamList noLoc ["total", "pubKeys", "sigIndices"] $ Fix $ CheckMultiSig noLoc (var' "total") (var' "pubKeys") (var' "sigIndices"))
-
-appendText :: Bind Lang
-appendText = bind Const.appendText (Fix $ LamList noLoc ["x", "y"] $ Fix $ TextE noLoc $ TextAppend noLoc x y)
-
-appendBytes :: Bind Lang
-appendBytes = bind Const.appendBytes (Fix $ LamList noLoc ["x", "y"] $ Fix $ BytesE noLoc $ BytesAppend noLoc x y)
-
-atVec :: Bind Lang
-atVec = bind Const.listAt (Fix $ LamList noLoc ["x", "y"] $ Fix $ VecE noLoc $ VecAt noLoc x y)
-
-fst :: Bind Lang
-fst = bind "fst" (lam' "x" $ Fix $ UnOpE noLoc (TupleAt 2 0) (var' "x"))
-
-snd :: Bind Lang
-snd = bind "snd" (lam' "x" $ Fix $ UnOpE noLoc (TupleAt 2 1) (var' "x"))
-
-otherwise :: Bind Lang
-otherwise = bind "otherwise" (Fix $ PrimE noLoc $ PrimBool P.True)
-
-undefined :: Bind Lang
-undefined = bind "undefined" (Fix $ FailCase noLoc)
-
-lam' :: Text -> Lang -> Lang
-lam' name expr = Fix $ Lam noLoc (PVar noLoc $ VarName noLoc name) expr
-
-var' :: Text -> Lang
-var' name = Fix $ Var noLoc (VarName noLoc name)
-
-f, x, y :: Lang
-f = Fix $ Var noLoc "f"
-x = Fix $ Var noLoc "x"
-y = Fix $ Var noLoc "y"
-
-aT, bT, cT :: Type
-aT = varT "a"
-bT = varT "b"
-cT = varT "c"
-
-bind :: Text -> Lang -> Bind Lang
-bind var body = simpleBind (VarName noLoc var) body
+      fmap (\ty -> assumeType (Const.deserialiseBytes $ argTypeName ty) (monoT $ bytesT ~> argTagToType ty)) argTypes
+
+    aT, bT, cT :: Type
+    aT = varT "a"
+    bT = varT "b"
+    cT = varT "c"
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/FromHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/FromHask.hs
@@ -66,7 +66,7 @@ fromHaskExp topExp = case topExp of
       "True"  -> bool True
       "False" -> bool False
       _       -> Fix $ Cons loc (varToConsName n) V.empty
-  H.List loc es -> fmap (Fix . VecE loc . NewVec loc . V.fromList) (mapM rec es)
+  H.List loc es -> fmap (Fix . List loc . V.fromList) (mapM rec es)
   H.InfixApp loc a op b -> fromInfixApp loc op a b
   H.Paren _ expr        -> rec expr
   H.LeftSection loc a op  -> rec $ unfoldLeftSection loc a op
@@ -74,7 +74,7 @@ fromHaskExp topExp = case topExp of
   H.Case loc expr alts -> liftA2 (fromCase loc) (rec expr) (mapM fromCaseAlt alts)
   H.RecConstr loc name fields -> liftA2 (fromRecConstr loc) (fromQName name) (mapM fromField fields)
   H.RecUpdate loc expr fields -> liftA2 (fromRecUpdate loc) (rec expr) (mapM fromField fields)
-  H.NegApp loc expr -> fmap (fromNegApp loc) (rec expr)
+  H.NegApp loc expr -> fmap (Fix . NegApp loc) (rec expr)
   other                 -> parseFailedBy "Failed to parse expression" other
   where
     rec = fromHaskExp
@@ -90,8 +90,6 @@ fromHaskExp topExp = case topExp of
 
     fromInfixApp loc op a b =
       liftA3 (\x v y -> Fix $ InfixApply loc x v y) (rec a) (fromOp op) (rec b)
-
-    fromNegApp loc a = Fix $ UnOpE loc Neg a
 
     fromOp = \case
       H.QVarOp _ qname -> fromQName qname

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/ToHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/ToHask.hs
@@ -5,8 +5,6 @@ module Hschain.Utxo.Lang.Parser.Hask.ToHask(
   , toHaskType
 ) where
 
-import Hex.Common.Text (showt)
-
 import Data.ByteString (ByteString)
 import Data.Fix
 
@@ -46,37 +44,17 @@ toHaskExp (Fix expr) = case expr of
   If loc a b c -> H.If loc (rec a) (rec b) (rec c)
   -- tuples
   Tuple loc ts -> H.Tuple loc H.Boxed (fmap rec $ V.toList ts)
-  -- operations
-  UnOpE loc op a -> fromUnOp loc op a
-  BinOpE loc op a b -> fromBimOp loc op a b
-  -- environment
-  GetEnv loc env -> fromEnv loc env
-  -- sigmas
-  SigmaE loc sigma -> fromSigma loc sigma
-  -- vectors
-  VecE loc vec -> fromVec loc vec
-  -- text
-  TextE loc txt -> fromText loc txt
-  -- bytes
-  BytesE loc bs -> fromBytes loc bs
-  -- boxes
-  BoxE loc box -> fromBox loc box
-  -- debug
-  Trace loc a b -> ap2 (VarName loc "trace") a b
+  List loc ts -> H.List loc (fmap rec $ V.toList ts)
+  NegApp loc a -> H.NegApp loc (rec a)
   FailCase loc -> H.Var loc (H.UnQual loc $ H.Ident loc "undefined")
   Let loc binds e -> H.Let loc (toLetBinds loc binds) (rec e)
   PrimLet loc binds e -> H.Let loc (toPrimLetBinds loc binds) (rec e)
-  CheckSig loc a b -> ap2 (VarName loc Const.checkSig) a b
-  CheckMultiSig loc a b c -> ap3 (VarName loc Const.checkMultiSig) a b c
   AltE _ _ _ -> error "Alt is for internal usage"
   AntiQuote loc mty name -> case mty of
     Just ty -> H.ExpTypeSig loc (H.SpliceExp loc (H.ParenSplice loc (toVar loc name))) (fromQuoteType loc ty)
     Nothing -> H.SpliceExp loc (H.ParenSplice loc (toVar loc name))
   where
     rec = toHaskExp
-    ap f x = H.App (HM.getLoc f) (toVar (HM.getLoc f) f) (rec x)
-    ap2 f x y = H.App (HM.getLoc y) (H.App (HM.getLoc f) (toVar (HM.getLoc f) f) (rec x)) (rec y)
-    ap3 f x y z = H.App (HM.getLoc z) (H.App (HM.getLoc y) (H.App (HM.getLoc f) (toVar (HM.getLoc f) f) (rec x)) (rec y)) (rec z)
     toLetBinds loc bg = H.BDecls loc $ toDecl bg
     toPrimLetBinds loc bg = H.BDecls loc $ toPrimDecl bg
 
@@ -87,93 +65,6 @@ toHaskExp (Fix expr) = case expr of
     toCaseAlt loc CaseExpr{..} = H.Alt loc (toPat caseExpr'lhs) (toRhs caseExpr'rhs) Nothing
       where
         toRhs = H.UnGuardedRhs loc . rec
-
-    fromUnOp loc op a = case op of
-      Not       -> ap (VarName loc "not") a
-      Neg       -> H.NegApp loc (rec a)
-      TupleAt size n -> ap2 (VarName loc $ mconcat ["tuple", showt size, "At"]) (Fix $ PrimE loc $ PrimInt $ fromIntegral n) a
-
-    fromBimOp loc op = case op of
-      And                   -> op2' "&&"
-      Or                    -> op2' "||"
-      Plus                  -> op2' "+"
-      Minus                 -> op2' "-"
-      Times                 -> op2' "*"
-      Div                   -> op2' "/"
-      Equals                -> op2' "=="
-      NotEquals             -> op2' "/="
-      LessThan              -> op2' "<"
-      GreaterThan           -> op2' ">"
-      LessThanEquals        -> op2' "<="
-      GreaterThanEquals     -> op2' ">="
-      where
-        op2' name a b = op2 loc name a b
-
-    fromEnv _ = \case
-      Height loc     -> toVar loc (VarName loc Const.getHeight)
-      Input loc a    -> ap (VarName loc "getInput") a
-      Output loc a   -> ap (VarName loc "getOutput") a
-      Self loc       -> toVar loc (VarName loc Const.getSelf)
-      Inputs loc     -> toVar loc (VarName loc Const.getInputs)
-      Outputs loc    -> toVar loc (VarName loc Const.getOutputs)
-      DataInputs loc -> toVar loc (VarName loc Const.getDataInputs)
-      GetVar loc ty  -> toVar loc (VarName loc $ getEnvVarName ty)
-
-    fromSigma _ = \case
-      Pk loc a        -> ap (VarName loc Const.pk) a
-      SOr loc a b     -> op2 loc Const.sigmaOr a b
-      SAnd loc a b    -> op2 loc Const.sigmaAnd a b
-      SPrimBool loc a -> ap (VarName loc Const.toSigma) a
-
-    fromVec _ = \case
-      NewVec loc vs     -> H.List loc (fmap rec $ V.toList vs)
-      VecAppend loc a b -> op2 loc "++" a b
-      VecAt loc a b     -> op2 loc "!" a b
-      VecLength loc     -> toVar loc (VarName loc Const.length)
-      VecMap loc        -> toVar loc (VarName loc Const.map)
-      VecFoldl loc      -> toVar loc (VarName loc Const.foldl)
-      VecFoldr loc      -> toVar loc (VarName loc Const.foldr)
-      VecFilter loc     -> toVar loc (VarName loc Const.filter)
-      VecAndSigma loc   -> toVar loc (VarName loc Const.andSigma)
-      VecOrSigma loc    -> toVar loc (VarName loc Const.orSigma)
-      VecAnd loc        -> toVar loc (VarName loc Const.and)
-      VecOr loc         -> toVar loc (VarName loc Const.or)
-      VecAnySigma loc   -> toVar loc (VarName loc Const.anySigma)
-      VecAllSigma loc   -> toVar loc (VarName loc Const.allSigma)
-      VecAny loc        -> toVar loc (VarName loc Const.any)
-      VecAll loc        -> toVar loc (VarName loc Const.all)
-      VecSum loc        -> toVar loc (VarName loc Const.sum)
-      VecProduct loc    -> toVar loc (VarName loc Const.product)
-
-
-    fromText _ = \case
-      TextAppend loc a b -> op2 loc "<>" a b
-      ConvertToText loc  -> toVar loc (VarName loc "show")
-      TextLength loc     -> toVar loc (VarName loc "lengthText")
-
-    fromBytes _ = \case
-      BytesAppend loc a b            -> ap2 (VarName loc Const.appendBytes) a b
-      BytesLength loc a              -> ap  (VarName loc $ Const.lengthBytes) a
-      SerialiseToBytes loc tag a     -> ap  (VarName loc $ Const.serialiseBytes $ argTypeName tag) a
-      DeserialiseFromBytes loc tag a -> ap  (VarName loc $ Const.deserialiseBytes $ argTypeName tag) a
-      BytesHash loc algo a           -> case algo of
-        Sha256     -> ap (VarName loc "sha256") a
-
-    fromBox _ = \case
-      BoxAt loc a field   -> fromBoxField loc a field
-
-    fromBoxField loc a = \case
-      BoxFieldId          -> get Const.getBoxId
-      BoxFieldValue       -> get Const.getBoxValue
-      BoxFieldScript      -> get Const.getBoxScript
-      BoxFieldArgList ty  -> get (getBoxArgVar ty)
-      BoxFieldPostHeight  -> get Const.getBoxPostHeight
-      where
-        get name = ap (VarName loc name) a
-
-    op2 :: Loc -> String -> Lang -> Lang -> H.Exp Loc
-    op2 loc name a b = H.InfixApp loc (rec a) (H.QVarOp loc $ H.UnQual loc $ H.Symbol loc name) (rec b)
-
 
 toLiteral :: Loc -> Prim -> H.Exp Loc
 toLiteral loc = \case

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Quoter.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Quoter.hs
@@ -80,7 +80,7 @@ import Hschain.Utxo.Lang.Expr
 import Hschain.Utxo.Lang.Sigma (Sigma, PublicKey)
 import Hschain.Utxo.Lang.Types (ArgType(..), Script)
 import Hschain.Utxo.Lang.Infer
-import Hschain.Utxo.Lang.Lib.Base (baseModuleCtx, baseLibTypeContext)
+import Hschain.Utxo.Lang.Lib.Base (baseLibInferCtx, baseLibTypeContext)
 import Hschain.Utxo.Lang.Parser.Hask
 import Hschain.Utxo.Lang.Pretty
 import Hschain.Utxo.Lang.Build (mainExprModule)
@@ -144,7 +144,7 @@ parseScript pos@(file, _, _) str =
   where
     typeCheckExpr e = do
       let (e', externalCtx) = substAntiQuoteExpr e
-      void $ checkError pos $ runInferM $ inferExpr (moduleCtx'types baseModuleCtx <> InferCtx externalCtx mempty) e'
+      void $ checkError pos $ runInferM $ inferExpr (baseLibInferCtx <> InferCtx externalCtx mempty) e'
       return e
 
     typeCheckModule m = do

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -174,9 +174,6 @@ instance Pretty (S.Sigma S.PublicKey) where
 instance Pretty S.PublicKey where
   pretty = pretty . encodeBase58
 
-op1 :: Doc ann -> Doc ann -> Doc ann
-op1 name a = hcat [name, parens a]
-
 instance Pretty (Expr a) where
   pretty (Expr a) = pretty a
 
@@ -191,27 +188,6 @@ instance Pretty Pat where
     PCons _ name args -> parens $ hsep [pretty name, hsep $ fmap pretty args]
     PTuple _ args -> parens $ hsep $ punctuate comma $ fmap pretty args
     -- PLit _ p    -> pretty p
-
-instance Pretty UnOp where
-  pretty = \case
-    Not -> "not"
-    Neg -> "negate"
-    TupleAt size n -> op1 (pretty $ mconcat ["tuple", show size, "-at"]) (pretty n)
-
-instance Pretty BinOp where
-  pretty = \case
-    And       -> "&&"
-    Or        -> "||"
-    Plus      -> "+"
-    Minus     -> "-"
-    Times     -> "*"
-    Div       -> "/"
-    Equals    -> "=="
-    NotEquals -> "/="
-    LessThan  -> "<"
-    GreaterThan -> ">"
-    LessThanEquals -> "<="
-    GreaterThanEquals -> ">="
 
 instance Pretty Prim where
   pretty = \case

--- a/hschain-utxo-repl/src/Hschain/Utxo/Repl/Imports.hs
+++ b/hschain-utxo-repl/src/Hschain/Utxo/Repl/Imports.hs
@@ -96,7 +96,9 @@ reload x = go (getLoadedFiles x) x
 -- | We do not need to include prelude definitions because
 -- they are inlined during compilation.
 loadBase :: Imports -> Imports
-loadBase imp = imp { imports'base = baseModuleCtx { moduleCtx'exprs = mempty } }
+loadBase imp = imp { imports'base = ModuleCtx
+  { moduleCtx'types = baseLibInferCtx
+  , moduleCtx'exprs = mempty } }
 
 updateCurrent :: Imports -> Imports
 updateCurrent = updateCtx . updateNames


### PR DESCRIPTION
I've noticed that we no longer need explicit constructors for high-level lang primops.

Otherwise we make redundant transformations.
* convert text to prim-ops constructors when parsing
* convert those prim-ops to text when doing inference and desugaring
* convert text to core prim ops

Instead we can keep them as text all the way up to conversion to core.
Also it simplifies prelude alot and code for inference.