### PR TITLE
Bump hshcain dependency

### DIFF
--- a/nix/versions.json
+++ b/nix/versions.json
@@ -1,7 +1,7 @@
 {
   "hschain": {
     "url": "https://github.com/hexresearch/hschain",
-    "rev": "dfb3f81379b984c6d9288e93b90d8d29179fa191",
+    "rev": "14109961c1d861d27d27423314d8a6d7eb54bab4",
     "ref": "master"
   }
 }


### PR DESCRIPTION
Nothing important. ByteReprSized superclass in crypto-related type classes are downgraded to ByteRepr