### PR TITLE
Proof sigma tuple

### DIFF
--- a/hschain-utxo-lang/hschain-utxo-lang.cabal
+++ b/hschain-utxo-lang/hschain-utxo-lang.cabal
@@ -65,6 +65,8 @@ library
       Hschain.Utxo.Lang.Parser.Quoter
       Hschain.Utxo.Lang.Pretty
       Hschain.Utxo.Lang.Sigma
+      Hschain.Utxo.Lang.Sigma.DTuple
+      Hschain.Utxo.Lang.Sigma.DLog
       Hschain.Utxo.Lang.Sigma.EllipticCurve
       Hschain.Utxo.Lang.Sigma.Interpreter
       Hschain.Utxo.Lang.Sigma.FiatShamirTree

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -60,10 +60,10 @@ toSigma loc = foldFix $ \case
     fromProofInput = \case
       Sigma.InputDLog   pk -> app loc "pk" [toText loc $ publicKeyToText pk]
       Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText . Sig.PublicKey)
-        [ Sigma.dtuple'generatorA dt
-        , Sigma.dtuple'generatorB dt
-        , Sigma.dtuple'publicKeyA dt
-        , Sigma.dtuple'publicKeyB dt
+        [ Sigma.dtuple'g    dt
+        , Sigma.dtuple'g_x  dt
+        , Sigma.dtuple'g_y  dt
+        , Sigma.dtuple'g_xy dt
         ]
 
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -30,7 +30,7 @@ import qualified Type.Check.HM as HM(LocFunctor(..), Type)
 import qualified Hschain.Utxo.Lang.Parser.Hask.ToHask as H(toHaskType)
 import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
-
+import qualified Hschain.Utxo.Lang.Sigma.Types as Sig
 
 toName :: VarName -> H.Name Loc
 toName (VarName loc txt) = H.Ident loc $ T.unpack txt
@@ -59,7 +59,12 @@ toSigma loc = foldFix $ \case
 
     fromProofInput = \case
       Sigma.InputDLog   pk -> app loc "pk" [toText loc $ publicKeyToText pk]
-      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText) [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
+      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText . Sig.PublicKey)
+        [ Sigma.dtuple'generatorA dt
+        , Sigma.dtuple'generatorB dt
+        , Sigma.dtuple'publicKeyA dt
+        , Sigma.dtuple'publicKeyB dt
+        ]
 
 
 toBytes :: Loc -> ByteString -> H.Exp Loc

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -29,7 +29,6 @@ import qualified Type.Check.HM as HM(LocFunctor(..), Type)
 
 import qualified Hschain.Utxo.Lang.Parser.Hask.ToHask as H(toHaskType)
 import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
-import qualified Hschain.Utxo.Lang.Sigma.DLog as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
 
 
@@ -59,8 +58,8 @@ toSigma loc = foldFix $ \case
     toQOp op = H.QVarOp loc (toQName $ VarName loc op)
 
     fromProofInput = \case
-      Sigma.InputDLog   (Sigma.DLog pk) -> app loc "pk" [toText loc $ publicKeyToText pk]
-      Sigma.InputDTuple dt              -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText) [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
+      Sigma.InputDLog   pk -> app loc "pk" [toText loc $ publicKeyToText pk]
+      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText) [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
 
 
 toBytes :: Loc -> ByteString -> H.Exp Loc

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -28,6 +28,10 @@ import qualified Language.Haskell.Exts.Syntax as H
 import qualified Type.Check.HM as HM(LocFunctor(..), Type)
 
 import qualified Hschain.Utxo.Lang.Parser.Hask.ToHask as H(toHaskType)
+import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
+import qualified Hschain.Utxo.Lang.Sigma.DLog as Sigma
+import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
+
 
 toName :: VarName -> H.Name Loc
 toName (VarName loc txt) = H.Ident loc $ T.unpack txt
@@ -44,18 +48,23 @@ toPat loc name = H.PVar loc $ toName (VarName loc name)
 toTypedPat :: Loc -> Typed (HM.Type () Name) Name -> H.Pat Loc
 toTypedPat loc (Typed name ty) = H.PatTypeSig loc (H.PVar loc $ toName $ VarName loc name) (toType loc ty)
 
-toSigma :: Loc -> Sigma PublicKey -> H.Exp Loc
+toSigma :: Loc -> Sigma ProofInput -> H.Exp Loc
 toSigma loc = foldFix $ \case
   SigmaBool b  -> H.App loc (H.Var loc $ toQName $ VarName loc "toSigma") (toBool loc b)
   SigmaAnd  as -> sigmaOp "&&" as
   SigmaOr   as -> sigmaOp "||" as
-  SigmaPk   pk -> H.App loc (H.Var loc $ toQName $ VarName loc "pk") (toText loc $ publicKeyToText pk)
+  SigmaPk   pk -> fromProofInput pk
   where
     sigmaOp op args = L.foldr1 (\a b -> H.InfixApp loc a (toQOp op) b) args
     toQOp op = H.QVarOp loc (toQName $ VarName loc op)
 
+    fromProofInput = \case
+      Sigma.InputDLog   (Sigma.DLog pk) -> app loc "pk" [toText loc $ publicKeyToText pk]
+      Sigma.InputDTuple dt              -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText) [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
+
+
 toBytes :: Loc -> ByteString -> H.Exp Loc
-toBytes loc bs = H.App loc (H.Var loc $ toQName $ VarName loc "pack58") (toText loc (encodeBase58 bs))
+toBytes loc bs = app loc "pack58" [toText loc (encodeBase58 bs)]
 
 toText :: Loc -> Text -> H.Exp Loc
 toText loc txt = H.Lit loc $ H.String loc (T.unpack txt) (T.unpack txt)
@@ -63,3 +72,7 @@ toText loc txt = H.Lit loc $ H.String loc (T.unpack txt) (T.unpack txt)
 toBool :: Loc -> Bool -> H.Exp Loc
 toBool loc b = H.Con loc $ toQName $ VarName loc $ showt b
 
+app :: Loc -> Text -> [H.Exp Loc] -> H.Exp Loc
+app loc name args = L.foldl' (H.App loc) op args
+  where
+    op = H.Var loc $ toQName $ VarName loc name

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Expr.hs
@@ -75,6 +75,7 @@ data PrimOp a
   | OpSigAnd              -- ^ AND for sigma expressions
   | OpSigOr               -- ^ OR for sigma expressions
   | OpSigPK               -- ^ Proof of key possession
+  | OpSigDTuple           -- ^ Proof of Diffie-Hellman tuple of keys
   | OpSigBool             -- ^ Lift boolean to the sigma expression
   | OpSigListAnd          -- ^ AND for list of sigma expression
   | OpSigListOr           -- ^ OR for list of sigma expression

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/TypeCheck.hs
@@ -186,6 +186,7 @@ primopToType = \case
   OpBoolNot -> pure $ BoolT :-> BoolT
   --
   OpSigPK        -> pure $ BytesT :-> SigmaT
+  OpSigDTuple    -> pure $ BytesT :-> BytesT :-> BytesT :-> SigmaT
   OpSigBool      -> pure $ BoolT  :-> SigmaT
   OpSigAnd       -> pure $ SigmaT :-> SigmaT :-> SigmaT
   OpSigOr        -> pure $ SigmaT :-> SigmaT :-> SigmaT

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Eval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Eval.hs
@@ -24,7 +24,7 @@ import Hschain.Utxo.Lang.Types
 
 -- | Executes spend-script in transaction. Spend script should be
 --   well-typed and evaluate to either sigma-expression or boolean.
-execScriptToSigma :: InputEnv -> Core Void -> Either Error (Sigma PublicKey)
+execScriptToSigma :: InputEnv -> Core Void -> Either Error (Sigma ProofInput)
 execScriptToSigma env prog = do
   -- Type check expression
   ty <- first (CoreScriptError . TypeCoreError)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
@@ -337,14 +337,10 @@ opComparison :: (TermVal -> TermVal -> Bool) -> Val
 opComparison f = liftTerm2 (\a b -> PrimVal $ PrimBool $ f a b)
 
 parsePublicKey :: ByteString -> Eval PublicKey
-parsePublicKey = parseBS err
-  where
-    err = "Can't parse public key"
+parsePublicKey = parseBS "Can't parse public key"
 
 parseGenerator :: ByteString -> Eval ECPoint
-parseGenerator = parseBS err
-  where
-    err = "Can't parse ECPoint"
+parseGenerator = parseBS "Can't parse ECPoint"
 
 parseBS :: ByteRepr a => String -> ByteString -> Eval a
 parseBS msg = maybe (throwError $ EvalErr msg) pure . decodeFromBS

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Types.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Types.hs
@@ -58,7 +58,7 @@ data Prim
   | PrimText  !Text
   | PrimBytes !ByteString
   | PrimBool  !Bool
-  | PrimSigma !(Sigma PublicKey)
+  | PrimSigma !(Sigma ProofInput)
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (NFData, Serialise)
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Desugar/ExtendedLC.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Desugar/ExtendedLC.hs
@@ -28,7 +28,6 @@ import Hschain.Utxo.Lang.Exec.Module (fixTopLevelPatBinds)
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 
-import qualified Hschain.Utxo.Lang.Core.Types as P
 import qualified Hschain.Utxo.Lang.Const as Const
 
 import qualified Type.Check.HM as H

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -834,6 +834,7 @@ monoPrimopName = \case
   OpSigAnd       -> Just Const.sigmaAnd
   OpSigOr        -> Just Const.sigmaOr
   OpSigPK        -> Just "pk"
+  OpSigDTuple    -> Just "dtuple"
   OpSigBool      -> Just "toSigma"
   OpSigListAnd   -> Just "andSigma"
   OpSigListOr    -> Just "orSigma"
@@ -919,7 +920,7 @@ monomorphicPrimops :: [PrimOp a]
 monomorphicPrimops =
   [ OpAdd, OpSub, OpMul, OpDiv, OpNeg
   , OpBoolAnd, OpBoolOr, OpBoolNot
-  , OpSigAnd, OpSigOr, OpSigPK, OpSigBool, OpSigListAnd, OpSigListOr
+  , OpSigAnd, OpSigOr, OpSigPK, OpSigDTuple, OpSigBool, OpSigListAnd, OpSigListOr
   , OpCheckSig, OpCheckMultiSig
   , OpSHA256, OpTextLength, OpBytesLength, OpTextAppend, OpBytesAppend
   , OpEnvGetHeight, OpEnvGetSelf, OpEnvGetInputs, OpEnvGetOutputs, OpEnvGetDataInputs

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -530,7 +530,7 @@ data Prim
   -- ^ Text values
   | PrimBool    Bool
   -- ^ Booleans
-  | PrimSigma   (Sigma PublicKey)
+  | PrimSigma   (Sigma ProofInput)
   -- ^ Sigma-expressions
   | PrimBytes ByteString
   deriving (Show, Eq, Ord, Generic, Serialise, NFData, Data, Typeable)
@@ -539,7 +539,7 @@ data Prim
 -- that user have to prove.
 data BoolExprResult
   = ConstBool Bool
-  | SigmaResult (Sigma PublicKey)
+  | SigmaResult (Sigma ProofInput)
   deriving (Show, Eq)
 
 instance ToJSON BoolExprResult where
@@ -961,7 +961,7 @@ instance ToLang Script where
 instance ToLang Bool where
   toLang loc b = toPrim loc $ PrimBool b
 
-instance ToLang (Sigma PublicKey) where
+instance ToLang (Sigma ProofInput) where
   toLang loc sig = toPrim loc $ PrimSigma sig
 
 instance ToLang Int where

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Lib/Base.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Lib/Base.hs
@@ -190,6 +190,7 @@ baseLibTypeContext = H.Context $ M.fromList $
   , assumeType Const.sigmaAnd (monoT $ sigmaT ~> sigmaT ~> sigmaT)
   , assumeType Const.sigmaOr (monoT $ sigmaT ~> sigmaT ~> sigmaT)
   , assumeType "pk" (monoT $ bytesT ~> sigmaT)
+  , assumeType "dtuple" (monoT $ bytesT ~> bytesT ~> bytesT ~> sigmaT)
   , assumeType "toSigma" (monoT $ boolT ~> sigmaT)
   , assumeType "+" (monoT $ intT ~> intT ~> intT)
   , assumeType "-" (monoT $ intT ~> intT ~> intT)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/ToHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/ToHask.hs
@@ -77,7 +77,7 @@ toLiteral loc = \case
     toText x = lit $ H.String loc (T.unpack x) (T.unpack x)
     lit = H.Lit loc
 
-    sigma :: Loc -> Sigma PublicKey -> H.Exp Loc
+    sigma :: Loc -> Sigma ProofInput -> H.Exp Loc
     sigma src x = foldFix go x
       where
         go = \case

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Quoter.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Quoter.hs
@@ -83,7 +83,7 @@ import Hschain.Utxo.Lang.Compile
 import Hschain.Utxo.Lang.Error
 import Hschain.Utxo.Lang.Exec.Module
 import Hschain.Utxo.Lang.Expr
-import Hschain.Utxo.Lang.Sigma (Sigma, PublicKey)
+import Hschain.Utxo.Lang.Sigma (Sigma, PublicKey, ProofInput)
 import Hschain.Utxo.Lang.Types (Script)
 import Hschain.Utxo.Lang.Infer
 import Hschain.Utxo.Lang.Lib.Base (baseLibInferCtx, baseLibTypeContext)
@@ -129,6 +129,7 @@ defQuoteModule str = do
                 `extQ` antiQuoteVar
                 `extQ` (fromLift @ByteString)
                 `extQ` (fromLift @Text)
+                `extQ` (fromLift @ProofInput)
                 `extQ` (fromLift @PublicKey)
              ) expr
   return modExpr

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -40,7 +40,6 @@ import qualified Hschain.Utxo.Lang.Const as Const
 import qualified Hschain.Utxo.Lang.Parser.Hask as P
 import qualified Hschain.Utxo.Lang.Sigma as S
 import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
-import qualified Hschain.Utxo.Lang.Sigma.DLog as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
 import qualified Hschain.Utxo.Lang.Crypto.Signature as Crypto
 
@@ -172,8 +171,8 @@ instance Pretty a => Pretty (S.Sigma a) where
 
 instance Pretty S.ProofInput where
   pretty = \case
-    Sigma.InputDLog (Sigma.DLog pk) -> pretty pk
-    Sigma.InputDTuple dt            -> parens $ hsep $ punctuate comma $ fmap pretty [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
+    Sigma.InputDLog   pk -> pretty pk
+    Sigma.InputDTuple dt -> parens $ hsep $ punctuate comma $ fmap pretty [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
 
 instance Pretty S.PublicKey where
   pretty = pretty . encodeBase58

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -39,6 +39,9 @@ import HSChain.Crypto.Classes (encodeToBS, encodeBase58)
 import qualified Hschain.Utxo.Lang.Const as Const
 import qualified Hschain.Utxo.Lang.Parser.Hask as P
 import qualified Hschain.Utxo.Lang.Sigma as S
+import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
+import qualified Hschain.Utxo.Lang.Sigma.DLog as Sigma
+import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
 import qualified Hschain.Utxo.Lang.Crypto.Signature as Crypto
 
 import qualified Type.Check.HM as H
@@ -160,12 +163,17 @@ instance Pretty Env where
 instance Pretty Proof where
   pretty proof = pretty $ P.ppShow proof
 
-instance Pretty (S.Sigma S.PublicKey) where
+instance Pretty a => Pretty (S.Sigma a) where
   pretty = foldFix $ \case
       S.SigmaPk k    -> parens $ hsep ["pk", pretty k]
       S.SigmaAnd as  -> parens $ hsep $ Const.sigmaAnd : as
       S.SigmaOr  as  -> parens $ hsep $ Const.sigmaOr  : as
       S.SigmaBool b  -> "Sigma" <> pretty b
+
+instance Pretty S.ProofInput where
+  pretty = \case
+    Sigma.InputDLog (Sigma.DLog pk) -> pretty pk
+    Sigma.InputDTuple dt            -> parens $ hsep $ punctuate comma $ fmap pretty [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
 
 instance Pretty S.PublicKey where
   pretty = pretty . encodeBase58
@@ -333,4 +341,5 @@ instance Pretty Module where
 
 instance Pretty TypedLamProg where
   pretty = pretty . prettyPrint . toHaskProg
+
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -35,12 +35,13 @@ import Language.Haskell.Exts.Pretty (prettyPrint)
 
 import qualified Data.Vector as V
 
-import HSChain.Crypto.Classes (encodeToBS, encodeBase58)
+import HSChain.Crypto.Classes (ByteRepr, encodeToBS, encodeBase58)
 import qualified Hschain.Utxo.Lang.Const as Const
 import qualified Hschain.Utxo.Lang.Parser.Hask as P
 import qualified Hschain.Utxo.Lang.Sigma as S
 import qualified Hschain.Utxo.Lang.Sigma.Protocol as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple as Sigma
+import qualified Hschain.Utxo.Lang.Sigma.EllipticCurve as EC
 import qualified Hschain.Utxo.Lang.Crypto.Signature as Crypto
 
 import qualified Type.Check.HM as H
@@ -175,6 +176,9 @@ instance Pretty S.ProofInput where
     Sigma.InputDTuple dt -> parens $ hsep $ punctuate comma $ fmap pretty [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
 
 instance Pretty S.PublicKey where
+  pretty = pretty . encodeBase58
+
+instance ByteRepr (EC.ECPoint a) => Pretty (EC.ECPoint a) where
   pretty = pretty . encodeBase58
 
 instance Pretty (Expr a) where

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -173,7 +173,8 @@ instance Pretty a => Pretty (S.Sigma a) where
 instance Pretty S.ProofInput where
   pretty = \case
     Sigma.InputDLog   pk -> pretty pk
-    Sigma.InputDTuple dt -> parens $ hsep $ punctuate comma $ fmap pretty [Sigma.dtuple'publicKeyA dt, Sigma.dtuple'publicKeyB dt]
+    Sigma.InputDTuple dt -> parens $ hsep $ punctuate comma $ fmap pretty
+      [Sigma.dtuple'g dt, Sigma.dtuple'g_x dt, Sigma.dtuple'g_y dt, Sigma.dtuple'g_xy dt]
 
 instance Pretty S.PublicKey where
   pretty = pretty . encodeBase58

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -80,7 +80,6 @@ import qualified Hschain.Utxo.Lang.Sigma.Interpreter           as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.EllipticCurve         as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.MultiSig              as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.Protocol              as Sigma
-import qualified Hschain.Utxo.Lang.Sigma.DLog                  as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.DTuple                as Sigma
 import qualified Hschain.Utxo.Lang.Sigma.Types                 as Sigma
 import Hschain.Utxo.Lang.Sigma.Interpreter (Prove, runProve)
@@ -420,8 +419,7 @@ checkChallenges commitments challenges message =
   Sigma.checkChallenges commitments challenges (encodeToBS message)
 
 dlogInput :: PublicKey -> ProofInput
-dlogInput key =
-  Sigma.InputDLog $ Sigma.DLog key
+dlogInput = Sigma.InputDLog
 
 dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
 dtupleInput genB keyA keyB =

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -422,7 +422,7 @@ dlogInput :: PublicKey -> ProofInput
 dlogInput = Sigma.InputDLog
 
 dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
-dtupleInput genB keyA keyB =
+dtupleInput genB (Sigma.PublicKey keyA) (Sigma.PublicKey keyB) =
   Sigma.InputDTuple $ Sigma.DTuple Sigma.groupGenerator genB keyA keyB
 
 $(deriveShow1 ''SigmaF)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -265,7 +265,7 @@ equalSigmaProof candidate proof =
 
 equalSigmaExpr :: Sigma PublicKey -> Sigma ProofDL -> Bool
 equalSigmaExpr (Fix x) (Fix y) = case (x, y) of
-  (SigmaPk pubKey, SigmaPk proof)  -> pubKey == Sigma.publicK proof
+  (SigmaPk pubKey, SigmaPk proof)  -> pubKey == Sigma.dlog'publicKey (Sigma.publicK proof)
   (SigmaOr as, SigmaOr bs)         -> equalList as bs
   (SigmaAnd as, SigmaAnd bs)       -> equalList as bs
   _                                -> False

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -7,6 +7,7 @@ module Hschain.Utxo.Lang.Sigma(
     CryptoAlg
   , KeyPair
   , PublicKey
+  , ECPoint
   , Secret
   , ProofEnv
   , ProofInput
@@ -15,6 +16,8 @@ module Hschain.Utxo.Lang.Sigma(
   , SigMessage(..)
   , Sigma
   , sigmaPk
+  , dlogSigma
+  , dtupleSigma
   , mapPk
   , mapPkM
   , SigmaF(..)
@@ -191,6 +194,12 @@ instance Boolean (Sigma k) where
 
 sigmaPk :: k -> Sigma k
 sigmaPk k = Fix $ SigmaPk k
+
+dlogSigma :: PublicKey -> Sigma ProofInput
+dlogSigma k = sigmaPk $ dlogInput k
+
+dtupleSigma :: ECPoint -> PublicKey -> PublicKey -> Sigma ProofInput
+dtupleSigma genB keyA keyB = sigmaPk $ dtupleInput genB keyA keyB
 
 -- | Sigma-expression
 data SigmaF k a =

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -1,3 +1,4 @@
+-- | Proof of discrete logarithm
 module Hschain.Utxo.Lang.Sigma.DLog(
     DLog(..)
   , ProofDLog(..)
@@ -19,15 +20,17 @@ import Hschain.Utxo.Lang.Sigma.Types
 
 import qualified Codec.Serialise as CBOR
 
+-- | Proof of discrete logarithm (key ownership)
 data ProofDLog a = ProofDLog
-  { proofDLog'public      :: DLog a
+  { proofDLog'public      :: DLog a         -- ^ input for proof
   , proofDLog'commitmentA :: Commitment a
   , proofDLog'responseZ   :: Response a
   , proofDLog'challengeE  :: Challenge a
   } deriving (Generic)
 
+-- | Input for proof of key ownership
 newtype DLog a = DLog
-  { dlog'publicKey :: PublicKey a
+  { dlog'publicKey :: PublicKey a  -- ^ Public key
   } deriving (Generic)
 
 deriving newtype instance ByteRepr (ECPoint a) => ByteRepr (DLog a)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -7,7 +7,12 @@ module Hschain.Utxo.Lang.Sigma.DLog(
   , getCommitmentDLog
 ) where
 
+import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON(..), FromJSON(..))
 import GHC.Generics (Generic)
+
+import HSChain.Crypto.Classes (ByteRepr(..))
+import HSChain.Crypto.Classes.Hash
 
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Types
@@ -21,9 +26,13 @@ data ProofDLog a = ProofDLog
   , proofDLog'challengeE  :: Challenge a
   } deriving (Generic)
 
-data DLog a = DLog
+newtype DLog a = DLog
   { dlog'publicKey :: PublicKey a
   } deriving (Generic)
+
+deriving newtype instance ByteRepr (ECPoint a) => ByteRepr (DLog a)
+deriving newtype instance (ByteRepr (ECPoint a)) => ToJSON (DLog a)
+deriving newtype instance (ByteRepr (ECPoint a)) => FromJSON (DLog a)
 
 newDLog :: EC a => Secret a -> DLog a
 newDLog secret = DLog $ getPublicKey secret
@@ -46,7 +55,10 @@ instance ( CBOR.Serialise (ECPoint   a)
 
 deriving instance Show (ECPoint a) => Show (DLog a)
 deriving instance Eq (ECPoint a)   => Eq (DLog a)
+deriving instance Ord (ECPoint a)   => Ord (DLog a)
 instance (CBOR.Serialise (ECPoint a)) => CBOR.Serialise (DLog a)
+deriving newtype instance NFData (ECPoint a) => NFData (DLog a)
+deriving newtype instance (CryptoHashable (ECPoint a)) => CryptoHashable (DLog a)
 
 -- | Simulate proof of posession of discrete logarithm for given
 -- challenge

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -1,4 +1,11 @@
--- | Proof of discrete logarithm
+-- | Proof of discrete logarithm of some arbitrary group element @u@
+-- with respect to a fixed generator @g@, where spender proves knowedge
+-- of @x@ such that
+--
+-- > u == g ^ x
+--
+-- This is derived from Schnorr signatures.
+--
 module Hschain.Utxo.Lang.Sigma.DLog(
     DLog(..)
   , ProofDLog(..)
@@ -20,15 +27,23 @@ import Hschain.Utxo.Lang.Sigma.Types
 
 import qualified Codec.Serialise as CBOR
 
--- | Proof of discrete logarithm (key ownership)
+-- | Proof of discrete logarithm of some arbitrary group element @u@
+-- with respect to a fixed generator @g@, where spender proves knowedge
+-- of @x@ such that
+--
+-- > u == g ^ x
+--
+-- It is based on zero-knowledge sigma protocols (Schnorr signatures).
 data ProofDLog a = ProofDLog
-  { proofDLog'public      :: DLog a         -- ^ input for proof
-  , proofDLog'commitmentA :: Commitment a
-  , proofDLog'responseZ   :: Response a
-  , proofDLog'challengeE  :: Challenge a
+  { proofDLog'public      :: DLog a         -- ^ input for proof (contains public key)
+  , proofDLog'commitmentA :: Commitment a   -- ^ commitment
+  , proofDLog'responseZ   :: Response a     -- ^ response
+  , proofDLog'challengeE  :: Challenge a    -- ^ challenge
   } deriving (Generic)
 
--- | Input for proof of key ownership
+-- | Input for proof of key ownership.
+-- We pass public key as point in the group that corresponds
+-- to secret that we need to prove.
 newtype DLog a = DLog
   { dlog'publicKey :: PublicKey a  -- ^ Public key
   } deriving (Generic)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -1,11 +1,10 @@
--- | Proof of discrete logarithm of some arbitrary group element @u@
--- with respect to a fixed generator @g@, where spender proves knowedge
--- of @x@ such that
---
--- > u == g ^ x
+-- |
+-- Proof of possession of discrete logarithm. This is non-interactive
+-- proof that spender know scalar (private key) @x@ such that @g^x =
+-- k@ where k is point on curve (public key), and @g@ is generator of
+-- curve.
 --
 -- This is derived from Schnorr signatures.
---
 module Hschain.Utxo.Lang.Sigma.DLog(
     DLog(..)
   , ProofDLog(..)
@@ -27,13 +26,14 @@ import Hschain.Utxo.Lang.Sigma.Types
 
 import qualified Codec.Serialise as CBOR
 
--- | Proof of discrete logarithm of some arbitrary group element @u@
--- with respect to a fixed generator @g@, where spender proves knowedge
--- of @x@ such that
+-- | Proof of possession of discrete logarithm (private key) of given
+-- point on curve (public key). Spender proves knowledge of scalar @x@
+-- such that
 --
 -- > u == g ^ x
 --
--- It is based on zero-knowledge sigma protocols (Schnorr signatures).
+-- where @u@ is public key. It is based on zero-knowledge sigma
+-- protocols (Schnorr signatures).
 data ProofDLog a = ProofDLog
   { proofDLog'public      :: DLog a         -- ^ input for proof (contains public key)
   , proofDLog'commitmentA :: Commitment a   -- ^ commitment

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -1,0 +1,69 @@
+module Hschain.Utxo.Lang.Sigma.DLog(
+    DLog(..)
+  , ProofDLog(..)
+  , newDLog
+  , verifyProofDLog
+  , simulateProofDLog
+  , getCommitmentDLog
+) where
+
+import GHC.Generics (Generic)
+
+import Hschain.Utxo.Lang.Sigma.EllipticCurve
+import Hschain.Utxo.Lang.Sigma.Types
+
+import qualified Codec.Serialise as CBOR
+
+data ProofDLog a = ProofDLog
+  { proofDLog'public      :: DLog a
+  , proofDLog'commitmentA :: Commitment a
+  , proofDLog'responseZ   :: Response a
+  , proofDLog'challengeE  :: Challenge a
+  } deriving (Generic)
+
+data DLog a = DLog
+  { dlog'publicKey :: PublicKey a
+  } deriving (Generic)
+
+newDLog :: EC a => Secret a -> DLog a
+newDLog secret = DLog $ getPublicKey secret
+
+deriving instance ( Show (ECPoint   a)
+                  , Show (ECScalar  a)
+                  , Show (Challenge a)
+                  ) => Show (ProofDLog a)
+
+deriving instance ( Eq (ECPoint   a)
+                  , Eq (ECScalar  a)
+                  , Eq (Challenge a)
+                  ) => Eq (ProofDLog a)
+
+instance ( CBOR.Serialise (ECPoint   a)
+         , CBOR.Serialise (ECScalar  a)
+         , CBOR.Serialise (Challenge a)
+         ) => CBOR.Serialise (ProofDLog a)
+
+
+deriving instance Show (ECPoint a) => Show (DLog a)
+deriving instance Eq (ECPoint a)   => Eq (DLog a)
+instance (CBOR.Serialise (ECPoint a)) => CBOR.Serialise (DLog a)
+
+-- | Simulate proof of posession of discrete logarithm for given
+-- challenge
+simulateProofDLog :: EC a => DLog a -> Challenge a -> IO (ProofDLog a)
+simulateProofDLog dl e = do
+  z <- generateScalar
+  return ProofDLog
+    { proofDLog'public      = dl
+    , proofDLog'commitmentA = getCommitment z e (dlog'publicKey dl)
+    , proofDLog'responseZ   = z
+    , proofDLog'challengeE  = e
+    }
+
+getCommitmentDLog :: EC a => Response a -> Challenge a -> DLog a -> Commitment a
+getCommitmentDLog z ch (DLog pk) = getCommitment z ch pk
+
+verifyProofDLog :: (EC a) => ProofDLog a -> Bool
+verifyProofDLog ProofDLog{..}
+  = fromGenerator proofDLog'responseZ == (proofDLog'commitmentA ^+^ (fromChallenge proofDLog'challengeE .*^ unPublicKey (dlog'publicKey proofDLog'public)))
+

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DLog.hs
@@ -6,20 +6,12 @@
 --
 -- This is derived from Schnorr signatures.
 module Hschain.Utxo.Lang.Sigma.DLog(
-    DLog(..)
-  , ProofDLog(..)
-  , newDLog
+    ProofDLog(..)
   , verifyProofDLog
   , simulateProofDLog
-  , getCommitmentDLog
-) where
+  ) where
 
-import Control.DeepSeq (NFData)
-import Data.Aeson (ToJSON(..), FromJSON(..))
 import GHC.Generics (Generic)
-
-import HSChain.Crypto.Classes (ByteRepr(..))
-import HSChain.Crypto.Classes.Hash
 
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Types
@@ -35,25 +27,12 @@ import qualified Codec.Serialise as CBOR
 -- where @u@ is public key. It is based on zero-knowledge sigma
 -- protocols (Schnorr signatures).
 data ProofDLog a = ProofDLog
-  { proofDLog'public      :: DLog a         -- ^ input for proof (contains public key)
-  , proofDLog'commitmentA :: Commitment a   -- ^ commitment
-  , proofDLog'responseZ   :: Response a     -- ^ response
-  , proofDLog'challengeE  :: Challenge a    -- ^ challenge
+  { proofDLog'public      :: PublicKey a
+    -- ^ Possession private key corresponding to this public key is proven
+  , proofDLog'commitmentA :: Commitment a
+  , proofDLog'responseZ   :: Response   a
+  , proofDLog'challengeE  :: Challenge  a
   } deriving (Generic)
-
--- | Input for proof of key ownership.
--- We pass public key as point in the group that corresponds
--- to secret that we need to prove.
-newtype DLog a = DLog
-  { dlog'publicKey :: PublicKey a  -- ^ Public key
-  } deriving (Generic)
-
-deriving newtype instance ByteRepr (ECPoint a) => ByteRepr (DLog a)
-deriving newtype instance (ByteRepr (ECPoint a)) => ToJSON (DLog a)
-deriving newtype instance (ByteRepr (ECPoint a)) => FromJSON (DLog a)
-
-newDLog :: EC a => Secret a -> DLog a
-newDLog secret = DLog $ getPublicKey secret
 
 deriving instance ( Show (ECPoint   a)
                   , Show (ECScalar  a)
@@ -70,30 +49,19 @@ instance ( CBOR.Serialise (ECPoint   a)
          , CBOR.Serialise (Challenge a)
          ) => CBOR.Serialise (ProofDLog a)
 
-
-deriving instance Show (ECPoint a) => Show (DLog a)
-deriving instance Eq (ECPoint a)   => Eq (DLog a)
-deriving instance Ord (ECPoint a)   => Ord (DLog a)
-instance (CBOR.Serialise (ECPoint a)) => CBOR.Serialise (DLog a)
-deriving newtype instance NFData (ECPoint a) => NFData (DLog a)
-deriving newtype instance (CryptoHashable (ECPoint a)) => CryptoHashable (DLog a)
-
 -- | Simulate proof of posession of discrete logarithm for given
 -- challenge
-simulateProofDLog :: EC a => DLog a -> Challenge a -> IO (ProofDLog a)
-simulateProofDLog dl e = do
+simulateProofDLog :: EC a => PublicKey a -> Challenge a -> IO (ProofDLog a)
+simulateProofDLog pubK e = do
   z <- generateScalar
   return ProofDLog
-    { proofDLog'public      = dl
-    , proofDLog'commitmentA = getCommitment z e (dlog'publicKey dl)
+    { proofDLog'public      = pubK
+    , proofDLog'commitmentA = getCommitment z e pubK
     , proofDLog'responseZ   = z
     , proofDLog'challengeE  = e
     }
 
-getCommitmentDLog :: EC a => Response a -> Challenge a -> DLog a -> Commitment a
-getCommitmentDLog z ch (DLog pk) = getCommitment z ch pk
-
 verifyProofDLog :: (EC a) => ProofDLog a -> Bool
 verifyProofDLog ProofDLog{..}
-  = fromGenerator proofDLog'responseZ == (proofDLog'commitmentA ^+^ (fromChallenge proofDLog'challengeE .*^ unPublicKey (dlog'publicKey proofDLog'public)))
+  = fromGenerator proofDLog'responseZ == (proofDLog'commitmentA ^+^ (fromChallenge proofDLog'challengeE .*^ unPublicKey proofDLog'public))
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -51,10 +51,10 @@ import qualified Codec.Serialise as CBOR
 
 -- | Diffie-Hellmann tuple.
 data DTuple a = DTuple
-  { dtuple'generatorA :: ECPoint a  -- ^ group generator @g@
-  , dtuple'generatorB :: ECPoint a  -- ^ @g^x@
-  , dtuple'publicKeyA :: ECPoint a  -- ^ @g^y@
-  , dtuple'publicKeyB :: ECPoint a  -- ^ @g^xy@
+  { dtuple'g    :: ECPoint a  -- ^ group generator @g@
+  , dtuple'g_x  :: ECPoint a  -- ^ @g^x@
+  , dtuple'g_y  :: ECPoint a  -- ^ @g^y@
+  , dtuple'g_xy :: ECPoint a  -- ^ @g^xy@
   } deriving (Generic)
 
 deriving instance Show (ECPoint a) => Show (DTuple a)
@@ -75,10 +75,11 @@ instance ByteRepr (ECPoint a) => ByteRepr (DTuple a) where
   encodeToBS = LB.toStrict . CBOR.serialise . toTuple
     where
       toTuple DTuple{..} =
-        ( encodeToBS dtuple'generatorA
-        , encodeToBS dtuple'generatorB
-        , encodeToBS dtuple'publicKeyA
-        , encodeToBS dtuple'publicKeyB)
+        ( encodeToBS dtuple'g
+        , encodeToBS dtuple'g_x
+        , encodeToBS dtuple'g_y
+        , encodeToBS dtuple'g_xy
+        )
 
 instance ByteRepr (ECPoint a) => ToJSON (DTuple a) where
   toJSON = defaultToJSON
@@ -114,8 +115,8 @@ verify gen a e z pub = z .*^ gen == a ^+^ (fromChallenge e .*^ pub)
 
 getCommitmentDTuple :: EC a => Response a -> Challenge a -> DTuple a -> (Commitment a, Commitment a)
 getCommitmentDTuple z ch DTuple{..} =
-  ( getCommitment z ch (PublicKey dtuple'publicKeyA)
-  , getCommitment z ch (PublicKey dtuple'publicKeyB)
+  ( getCommitment z ch (PublicKey dtuple'g_y)
+  , getCommitment z ch (PublicKey dtuple'g_xy)
   )
 
 -- | Simulate proof of posession of discrete logarithm for given

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -1,0 +1,90 @@
+module Hschain.Utxo.Lang.Sigma.DTuple(
+    DTuple(..)
+  , ProofDTuple(..)
+  , newDTuple
+  , verifyProofDTuple
+  , simulateProofDTuple
+  , getCommitmentDTuple
+) where
+
+import GHC.Generics (Generic)
+
+import Hschain.Utxo.Lang.Sigma.EllipticCurve
+import Hschain.Utxo.Lang.Sigma.Types
+
+import qualified Codec.Serialise as CBOR
+
+-- | Proof of knowledge of Diffie-Hellman tuple
+data DTuple a = DTuple
+  { dtuple'generatorA :: ECPoint a
+  , dtuple'generatorB :: ECPoint a
+  , dtuple'publicKeyA :: PublicKey a
+  , dtuple'publicKeyB :: PublicKey a
+  } deriving (Generic)
+
+deriving instance Show (ECPoint a) => Show (DTuple a)
+deriving instance Eq (ECPoint a)   => Eq (DTuple a)
+instance (CBOR.Serialise (ECPoint a)) => CBOR.Serialise (DTuple a)
+
+data ProofDTuple a = ProofDTuple
+  { proofDTuple'public      :: DTuple a
+  , proofDTuple'commitmentA :: (Commitment a, Commitment a)
+  , proofDTuple'responseZ   :: Response a
+  , proofDTuple'challengeE  :: Challenge a
+  } deriving (Generic)
+
+deriving instance (Show (ECPoint a), Show (Response a), Show (Challenge a)) => Show (ProofDTuple a)
+deriving instance (Eq (ECPoint a), Eq (Response a), Eq (Challenge a)) => Eq (ProofDTuple a)
+instance (CBOR.Serialise (ECPoint a), CBOR.Serialise (Response a), CBOR.Serialise (Challenge a)) => CBOR.Serialise (ProofDTuple a)
+
+newDTuple :: EC a => Secret a -> IO (DTuple a)
+newDTuple (Secret secret) = do
+  (genA, genB) <- newGenPair
+  return $ DTuple
+    { dtuple'generatorA = genA
+    , dtuple'generatorB = genB
+    , dtuple'publicKeyA = PublicKey $ secret .*^ genA
+    , dtuple'publicKeyB = PublicKey $ secret .*^ genB
+    }
+  where
+    newGenPair = do
+      let genA = groupGenerator
+      genB <- newRandomGenerator
+      return (genA, genB)
+
+    newRandomGenerator = do
+      sc <- generateScalar
+      let res = fromGenerator sc
+      if isIdentity res
+        then newRandomGenerator
+        else return res
+
+verifyProofDTuple :: EC a => ProofDTuple a -> Bool
+verifyProofDTuple ProofDTuple{..} =
+     verify g a e z u
+  && verify h b e z v
+  where
+    DTuple g h u v = proofDTuple'public
+    (a, b) = proofDTuple'commitmentA
+    e = proofDTuple'challengeE
+    z = proofDTuple'responseZ
+
+verify :: EC a => ECPoint a -> ECPoint a -> Challenge a -> ECScalar a -> PublicKey a -> Bool
+verify gen a e z (PublicKey pub) = z .*^ gen == a ^+^ (fromChallenge e .*^ pub)
+
+
+getCommitmentDTuple :: EC a => Response a -> Challenge a -> DTuple a -> (Commitment a, Commitment a)
+getCommitmentDTuple z ch DTuple{..} = (getCommitment z ch dtuple'publicKeyA, getCommitment z ch dtuple'publicKeyB)
+
+-- | Simulate proof of posession of discrete logarithm for given
+-- challenge
+simulateProofDTuple :: EC a => DTuple a -> Challenge a -> IO (ProofDTuple a)
+simulateProofDTuple dt e = do
+  z <- generateScalar
+  return ProofDTuple
+    { proofDTuple'public      = dt
+    , proofDTuple'commitmentA = getCommitmentDTuple z e dt
+    , proofDTuple'responseZ   = z
+    , proofDTuple'challengeE  = e
+    }
+

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -1,3 +1,10 @@
+-- | Proof of knowledge of Diffie-Hellman tuple.
+-- As described in "Advanced ErgoScript tutorial" (Section 3.3)
+--
+-- Let @g@, @h@, @u@, @v@ be public group elements. The
+-- prover proves the knowledge of @x@ such as
+--
+-- > u == g ^ x  &&  v == h ^ x
 module Hschain.Utxo.Lang.Sigma.DTuple(
     DTuple(..)
   , ProofDTuple(..)
@@ -22,12 +29,12 @@ import Hschain.Utxo.Lang.Sigma.Types
 import qualified Data.ByteString.Lazy as LB
 import qualified Codec.Serialise as CBOR
 
--- | Proof of knowledge of Diffie-Hellman tuple
+-- | Public input for knowledge of Diffie-Hellman tuple.
 data DTuple a = DTuple
-  { dtuple'generatorA :: ECPoint a
-  , dtuple'generatorB :: ECPoint a
-  , dtuple'publicKeyA :: PublicKey a
-  , dtuple'publicKeyB :: PublicKey a
+  { dtuple'generatorA :: ECPoint a    -- ^ first group element (normally it is the group generator)
+  , dtuple'generatorB :: ECPoint a    -- ^ second group element
+  , dtuple'publicKeyA :: PublicKey a  -- ^ public key for first group element
+  , dtuple'publicKeyB :: PublicKey a  -- ^ public key for second group element
   } deriving (Generic)
 
 deriving instance Show (ECPoint a) => Show (DTuple a)
@@ -59,6 +66,7 @@ instance ByteRepr (ECPoint a) => ToJSON (DTuple a) where
 instance ByteRepr (ECPoint a) => FromJSON (DTuple a) where
   parseJSON = defaultParseJSON "DTuple"
 
+-- | Proof of knowledge of Diffie-Hellman tuple
 data ProofDTuple a = ProofDTuple
   { proofDTuple'public      :: DTuple a
   , proofDTuple'commitmentA :: (Commitment a, Commitment a)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -29,7 +29,6 @@
 module Hschain.Utxo.Lang.Sigma.DTuple(
     DTuple(..)
   , ProofDTuple(..)
-  , newDTuple
   , verifyProofDTuple
   , simulateProofDTuple
   , getCommitmentDTuple
@@ -98,28 +97,6 @@ data ProofDTuple a = ProofDTuple
 deriving instance (Show (ECPoint a), Show (Response a), Show (Challenge a)) => Show (ProofDTuple a)
 deriving instance (Eq (ECPoint a), Eq (Response a), Eq (Challenge a)) => Eq (ProofDTuple a)
 instance (CBOR.Serialise (ECPoint a), CBOR.Serialise (Response a), CBOR.Serialise (Challenge a)) => CBOR.Serialise (ProofDTuple a)
-
-newDTuple :: EC a => Secret a -> IO (DTuple a)
-newDTuple (Secret secret) = do
-  (genA, genB) <- newGenPair
-  return $ DTuple
-    { dtuple'generatorA = genA
-    , dtuple'generatorB = genB
-    , dtuple'publicKeyA = PublicKey $ secret .*^ genA
-    , dtuple'publicKeyB = PublicKey $ secret .*^ genB
-    }
-  where
-    newGenPair = do
-      let genA = groupGenerator
-      genB <- newRandomGenerator
-      return (genA, genB)
-
-    newRandomGenerator = do
-      sc <- generateScalar
-      let res = fromGenerator sc
-      if isIdentity res
-        then newRandomGenerator
-        else return res
 
 verifyProofDTuple :: EC a => ProofDTuple a -> Bool
 verifyProofDTuple ProofDTuple{..} =

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -1,10 +1,31 @@
--- | Proof of knowledge of Diffie-Hellman tuple.
--- As described in "Advanced ErgoScript tutorial" (Section 3.3)
+-- |
 --
--- Let @g@, @h@, @u@, @v@ be public group elements. The
--- prover proves the knowledge of @x@ such as
+-- Noninteractive proof that tuple is indeed Diffie-Hellman (DH) tuple.
+-- DH tuple is one of the form
 --
--- > u == g ^ x  &&  v == h ^ x
+-- > (g, h=g^x, u=g^y, v=g^xy)
+--
+-- where @g@ is group generators and @x@,@y@ unknown constant Prover
+-- demonstrates that he knows @y@ without disclosing it. Note that he
+-- doesn't need to know @x@.
+--
+-- == Noninteractive protocol
+--
+-- 1. Prover chooses random @r : ℤ/q@ and keeps it secret. Then he
+--    sends to verifier following commitments:
+--
+-- > t0 = g^r
+-- > t1 = h^r = g^rx
+--
+-- 2. Verifier chooses random challenge @c : ℤ/q@, such @c@ is
+--    generated using hash of @t0@,@t1@ and message.
+--
+-- 3. Prover computes @z = r + cy@ and sends it to verifier.
+--
+-- 4. Verifier accepts proof if
+--
+-- > g^z = t0·u^c = g^r·g^cy
+-- > h^z = t1·v^c = g^rx·g^cxy
 module Hschain.Utxo.Lang.Sigma.DTuple(
     DTuple(..)
   , ProofDTuple(..)
@@ -29,12 +50,12 @@ import Hschain.Utxo.Lang.Sigma.Types
 import qualified Data.ByteString.Lazy as LB
 import qualified Codec.Serialise as CBOR
 
--- | Public input for knowledge of Diffie-Hellman tuple.
+-- | Diffie-Hellmann tuple.
 data DTuple a = DTuple
-  { dtuple'generatorA :: ECPoint a    -- ^ first group element (normally it is the group generator)
-  , dtuple'generatorB :: ECPoint a    -- ^ second group element
-  , dtuple'publicKeyA :: PublicKey a  -- ^ public key for first group element
-  , dtuple'publicKeyB :: PublicKey a  -- ^ public key for second group element
+  { dtuple'generatorA :: ECPoint a    -- ^ group generator @g@
+  , dtuple'generatorB :: ECPoint a    -- ^ @g^x@
+  , dtuple'publicKeyA :: PublicKey a  -- ^ @g^y@
+  , dtuple'publicKeyB :: PublicKey a  -- ^ @g^xy@
   } deriving (Generic)
 
 deriving instance Show (ECPoint a) => Show (DTuple a)
@@ -66,7 +87,7 @@ instance ByteRepr (ECPoint a) => ToJSON (DTuple a) where
 instance ByteRepr (ECPoint a) => FromJSON (DTuple a) where
   parseJSON = defaultParseJSON "DTuple"
 
--- | Proof of knowledge of Diffie-Hellman tuple
+-- | Proof of knowledge of @y@ in Diffie-Hellman tuple
 data ProofDTuple a = ProofDTuple
   { proofDTuple'public      :: DTuple a                      -- ^ public input for the algorithm
   , proofDTuple'commitmentA :: (Commitment a, Commitment a)  -- ^ commitments

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -68,10 +68,10 @@ instance ByteRepr (ECPoint a) => FromJSON (DTuple a) where
 
 -- | Proof of knowledge of Diffie-Hellman tuple
 data ProofDTuple a = ProofDTuple
-  { proofDTuple'public      :: DTuple a
-  , proofDTuple'commitmentA :: (Commitment a, Commitment a)
-  , proofDTuple'responseZ   :: Response a
-  , proofDTuple'challengeE  :: Challenge a
+  { proofDTuple'public      :: DTuple a                      -- ^ public input for the algorithm
+  , proofDTuple'commitmentA :: (Commitment a, Commitment a)  -- ^ commitments
+  , proofDTuple'responseZ   :: Response a                    -- ^ response
+  , proofDTuple'challengeE  :: Challenge a                   -- ^ challenge
   } deriving (Generic)
 
 deriving instance (Show (ECPoint a), Show (Response a), Show (Challenge a)) => Show (ProofDTuple a)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/DTuple.hs
@@ -51,10 +51,10 @@ import qualified Codec.Serialise as CBOR
 
 -- | Diffie-Hellmann tuple.
 data DTuple a = DTuple
-  { dtuple'generatorA :: ECPoint a    -- ^ group generator @g@
-  , dtuple'generatorB :: ECPoint a    -- ^ @g^x@
-  , dtuple'publicKeyA :: PublicKey a  -- ^ @g^y@
-  , dtuple'publicKeyB :: PublicKey a  -- ^ @g^xy@
+  { dtuple'generatorA :: ECPoint a  -- ^ group generator @g@
+  , dtuple'generatorB :: ECPoint a  -- ^ @g^x@
+  , dtuple'publicKeyA :: ECPoint a  -- ^ @g^y@
+  , dtuple'publicKeyB :: ECPoint a  -- ^ @g^xy@
   } deriving (Generic)
 
 deriving instance Show (ECPoint a) => Show (DTuple a)
@@ -108,12 +108,15 @@ verifyProofDTuple ProofDTuple{..} =
     e = proofDTuple'challengeE
     z = proofDTuple'responseZ
 
-verify :: EC a => ECPoint a -> ECPoint a -> Challenge a -> ECScalar a -> PublicKey a -> Bool
-verify gen a e z (PublicKey pub) = z .*^ gen == a ^+^ (fromChallenge e .*^ pub)
+verify :: EC a => ECPoint a -> ECPoint a -> Challenge a -> ECScalar a -> ECPoint a -> Bool
+verify gen a e z pub = z .*^ gen == a ^+^ (fromChallenge e .*^ pub)
 
 
 getCommitmentDTuple :: EC a => Response a -> Challenge a -> DTuple a -> (Commitment a, Commitment a)
-getCommitmentDTuple z ch DTuple{..} = (getCommitment z ch dtuple'publicKeyA, getCommitment z ch dtuple'publicKeyB)
+getCommitmentDTuple z ch DTuple{..} =
+  ( getCommitment z ch (PublicKey dtuple'publicKeyA)
+  , getCommitment z ch (PublicKey dtuple'publicKeyB)
+  )
 
 -- | Simulate proof of posession of discrete logarithm for given
 -- challenge

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -52,9 +52,6 @@ class ( ByteRepr (ECPoint   a)
 
   fromChallenge     :: Challenge a -> ECScalar a
 
-  isIdentity        :: ECPoint a -> Bool
-  -- ^ checks weather element is identity
-
   groupGenerator    :: ECPoint a
   -- ^ generator of the group
 
@@ -126,8 +123,6 @@ instance EC Ed25519 where
     = ChallengeEd25519
     $ BS.pack
     $ BS.zipWith xor a b
-
-  isIdentity = coerce Ed.pointHasPrimeOrder
 
   generateScalar    = coerce (Ed.scalarGenerate @IO)
   fromGenerator     = coerce Ed.toPoint

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/EllipticCurve.hs
@@ -45,10 +45,18 @@ class ( ByteRepr (ECPoint   a)
   xorChallenge      :: Challenge a -> Challenge a -> Challenge a
 
   generateScalar    :: IO (ECScalar a)
+  -- ^ generates random scalar
+
   fromGenerator     :: ECScalar  a -> ECPoint  a
+  -- ^ multiplies generator of the group N times (first argument)
+
   fromChallenge     :: Challenge a -> ECScalar a
+
   isIdentity        :: ECPoint a -> Bool
+  -- ^ checks weather element is identity
+
   groupGenerator    :: ECPoint a
+  -- ^ generator of the group
 
   (.+.)   :: ECScalar a -> ECScalar a -> ECScalar a
   (.*.)   :: ECScalar a -> ECScalar a -> ECScalar a

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/FiatShamirTree.hs
@@ -15,7 +15,6 @@ module Hschain.Utxo.Lang.Sigma.FiatShamirTree(
 
 import GHC.Generics (Generic)
 
-import Hschain.Utxo.Lang.Sigma.DLog
 import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Protocol
@@ -35,7 +34,7 @@ data FiatShamir a
 -- | Leaf of Fiat-Shamir tree.
 data FiatShamirLeaf a
   = FiatShamirLeafDLog
-      { fsLeafDLog'public     :: DLog a
+      { fsLeafDLog'public     :: PublicKey a
       , fsLeafDLog'commitment :: Commitment a
       }
   | FiatShamirLeafDTuple

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Interpreter.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Interpreter.hs
@@ -202,7 +202,7 @@ toProof tree = Prove $ ExceptT $ pure $ liftA2 Proof (getRootChallenge tree) (ge
 
 ownsKey :: EC a => Set (PublicKey a) -> ProofInput a -> Bool
 ownsKey knownPKs = \case
-  InputDLog (DLog k)     -> checkKey k
+  InputDLog   k          -> checkKey k
   InputDTuple DTuple{..} -> checkKey dtuple'publicKeyA
   where
     checkKey k = k `Set.member` knownPKs
@@ -215,7 +215,7 @@ markTree knownPKs = clean . check
 
     -- Prover Step 1: Mark as real everything the prover can prove
     check = \case
-      Leaf () inp@(InputDLog (DLog k))     -> Leaf (checkKey k) inp
+      Leaf () inp@(InputDLog k)            -> Leaf (checkKey k) inp
       Leaf () inp@(InputDTuple DTuple{..}) -> Leaf (checkKey dtuple'publicKeyA) inp
       AND  () es -> AND k es'
         where
@@ -336,7 +336,7 @@ getPrivateKeyForInput :: EC a => Env a -> ProofInput a -> Secret a
 getPrivateKeyForInput (Env env) = \case
   InputDLog dlog ->
     let [sk] = [ secretKey | KeyPair{..} <- env
-                                  , dlog'publicKey dlog == publicKey
+                                  , dlog == publicKey
                                   ]
     in  sk
   InputDTuple dtuple ->
@@ -455,7 +455,7 @@ completeProvenTree Proof{..} = go proof'rootChallenge proof'tree
     getAtomicProof ch proofInp respZ = case proofInp of
       InputDLog dlog -> ProofDL $ ProofDLog
         { proofDLog'public      = dlog
-        , proofDLog'commitmentA = getCommitmentDLog respZ ch dlog
+        , proofDLog'commitmentA = getCommitment respZ ch dlog
         , proofDLog'responseZ   = respZ
         , proofDLog'challengeE  = ch
         }

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Interpreter.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Interpreter.hs
@@ -27,6 +27,8 @@ import Control.Monad.IO.Class
 import Control.Monad.Except
 
 import HSChain.Crypto.Classes.Hash (CryptoHashable(..), genericHashStep)
+import Hschain.Utxo.Lang.Sigma.DLog
+import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.FiatShamirTree
 import Hschain.Utxo.Lang.Sigma.Protocol
@@ -76,10 +78,10 @@ deriving stock   instance Show (Challenge a) => Show (ProofTag a)
 
 -- Partial proof of possession of discrete logarithm
 data PartialProof a = PartialProof
-  { pproofPK :: PublicKey a
-  , pproofR  :: ECScalar  a
-  , pproofA  :: ECPoint   a
+  { pproofInput :: ProofInput a
+  , pproofR     :: ECScalar  a
   }
+
 deriving instance ( Show (ECPoint   a)
                   , Show (Secret    a)
                   , Show (ECScalar a)
@@ -113,7 +115,7 @@ deriving anyclass instance (NFData (ECPoint a), NFData (ECScalar a), NFData (Cha
 data ProvenTree a
   = ProvenLeaf
       { provenLeaf'responseZ :: ECScalar a
-      , provenLeaf'publicK   :: PublicKey a
+      , provenLeaf'publicK   :: ProofInput a
       }
   | ProvenOr
       { provenOr'leftmost  :: ProvenTree a
@@ -163,7 +165,7 @@ deriving anyclass instance (NFData (ECPoint a), NFData (ECScalar a), NFData (Cha
 
 -- | Create proof for sigma expression based on ownership of collection of keys (@Env@)
 newProof :: (EC a)
-  => Env a -> SigmaE () (PublicKey a) -> ByteString -> IO (Either Text (Proof a))
+  => Env a -> SigmaE () (ProofInput a) -> ByteString -> IO (Either Text (Proof a))
 newProof env expr message = runProve $ do
   commitments <- generateCommitments (markTree knownKeys expr)
   toProof =<< generateProofs env commitments message
@@ -171,14 +173,14 @@ newProof env expr message = runProve $ do
     knownKeys = Set.fromList $ publicKey <$> unEnv env
 
 -- Syntactic step that performs a type conversion only
-toProof :: SigmaE (ProofTag a) (ProofDL a) -> Prove (Proof a)
+toProof :: SigmaE (ProofTag a) (AtomicProof a) -> Prove (Proof a)
 toProof tree = Prove $ ExceptT $ pure $ liftA2 Proof (getRootChallenge tree) (getProvenTree tree)
   where
     getRootChallenge =
       maybe (Left "No root challenge") Right . proofTag'challenge . sexprAnn
 
     getProvenTree ptree = case ptree of
-      Leaf _ p  -> Right $ ProvenLeaf (responseZ p) (publicK p)
+      Leaf _ p  -> Right $ ProvenLeaf (responseZ p) (getProofInput p)
       AND _ es  -> ProvenAnd  <$> traverse getProvenTree es
       OR  _ es  -> case es of
         []   -> Left "No children for OR-node"
@@ -197,12 +199,15 @@ toProof tree = Prove $ ExceptT $ pure $ liftA2 Proof (getRootChallenge tree) (ge
 
 
 -- Mark all nodes according to whether we can produce proof for them
-markTree :: (EC a) => Set (PublicKey a) -> SigmaE () (PublicKey a) -> SigmaE ProofVar (PublicKey a)
+markTree :: (EC a) => Set (PublicKey a) -> SigmaE () (ProofInput a) -> SigmaE ProofVar (ProofInput a)
 markTree knownPKs = clean . check
   where
+    checkKey k = (if k `Set.member` knownPKs then Real else Simulated)
+
     -- Prover Step 1: Mark as real everything the prover can prove
     check = \case
-      Leaf () k  -> Leaf (if k `Set.member` knownPKs then Real else Simulated) k
+      Leaf () inp@(InputDLog (DLog k))     -> Leaf (checkKey k) inp
+      Leaf () inp@(InputDTuple DTuple{..}) -> Leaf (checkKey dtuple'publicKeyA) inp
       AND  () es -> AND k es'
         where
           es'  = map check es
@@ -237,8 +242,8 @@ markTree knownPKs = clean . check
 -- compute commitments for real leaves
 generateCommitments
   :: (EC a)
-  => SigmaE ProofVar (PublicKey a)
-  -> Prove (SigmaE (ProofTag a) (Either (PartialProof a) (ProofDL a)))
+  => SigmaE ProofVar (ProofInput a)
+  -> Prove (SigmaE (ProofTag a) (Either (PartialProof a) (AtomicProof a)))
 generateCommitments tree = case sexprAnn tree of
   Real      -> goReal tree
   -- Prover Step 2: If the root of the tree is marked "simulated" then the prover does not have enough witnesses
@@ -249,9 +254,8 @@ generateCommitments tree = case sexprAnn tree of
     goReal = \case
       Leaf Real k -> do r <- liftIO generateScalar
                         return $ Leaf (ProofTag Real Nothing) $ Left $ PartialProof
-                          { pproofPK = k
-                          , pproofR  = r
-                          , pproofA  = fromGenerator r
+                          { pproofInput = k
+                          , pproofR     = r
                           }
       AND Real es -> AND (ProofTag Real Nothing) <$> traverse goReal     es
       OR  Real es -> OR  (ProofTag Real Nothing) <$> traverse simulateOR es
@@ -263,7 +267,7 @@ generateCommitments tree = case sexprAnn tree of
       _ -> throwError "Simulated node!"
     --
     goSim ch = \case
-      Leaf Simulated k      -> liftIO $ Leaf (ProofTag Simulated $ Just ch) . Right <$> simulateProofDL k ch
+      Leaf Simulated k      -> liftIO $ Leaf (ProofTag Simulated $ Just ch) . Right <$> simulateAtomicProof k ch
       AND  Simulated es     -> AND  (ProofTag Simulated $ Just ch) <$> traverse (goSim ch) es
       OR   Simulated []     -> throwError "Empty OR"
       OR   Simulated (e:es) -> do esWithCh <- liftIO $ forM es $ \x -> (,x) <$> generateChallenge
@@ -281,25 +285,34 @@ initRootChallenge expr message =
 
 getProofRootChallenge ::
      (EC a)
-  => SigmaE (ProofTag a) (Either (PartialProof a) (ProofDL a))
+  => SigmaE (ProofTag a) (Either (PartialProof a) (AtomicProof a))
   -> ByteString
   -> Challenge a
 getProofRootChallenge expr message = getRootChallengeBy extractCommitment expr message
   where
-    extractCommitment :: Either (PartialProof a) (ProofDL a) -> FiatShamirLeaf a
-    extractCommitment =
-      either
-        (\x -> FiatShamirLeaf (pproofPK x) (pproofA x))
-        (\x -> FiatShamirLeaf (publicK x)  (commitmentA x))
+    extractCommitment :: Either (PartialProof a) (AtomicProof a) -> FiatShamirLeaf a
+    extractCommitment = either extractPartialProof extractAtomicProof
+
+    extractPartialProof x = case pproofInput x of
+      InputDLog dlog -> FiatShamirLeafDLog dlog  (fromGenerator rnd)
+      InputDTuple dt -> FiatShamirLeafDTuple dt  (rnd .*^ dtuple'generatorA dt, rnd .*^ dtuple'generatorB dt)
+      where
+        rnd = pproofR x
+
+    extractAtomicProof = \case
+      ProofDL dlog   -> FiatShamirLeafDLog   (proofDLog'public dlog)     (proofDLog'commitmentA dlog)
+      ProofDT dtuple -> FiatShamirLeafDTuple (proofDTuple'public dtuple) (proofDTuple'commitmentA dtuple)
 
 getVerifyRootChallenge ::
      (EC a)
-  => SigmaE k (ProofDL a)
+  => SigmaE k (AtomicProof a)
   -> ByteString
   -> Challenge a
 getVerifyRootChallenge expr message = getRootChallengeBy extractFiatShamirLeaf expr message
   where
-    extractFiatShamirLeaf ProofDL{..} = FiatShamirLeaf publicK commitmentA
+    extractFiatShamirLeaf = \case
+      ProofDL ProofDLog{..}   -> FiatShamirLeafDLog   proofDLog'public   proofDLog'commitmentA
+      ProofDT ProofDTuple{..} -> FiatShamirLeafDTuple proofDTuple'public proofDTuple'commitmentA
 
 getRootChallengeBy ::
      EC a
@@ -313,9 +326,9 @@ getRootChallengeBy extract expr message =
 generateProofs
   :: forall a. (EC a)
   => Env a
-  -> SigmaE (ProofTag a) (Either (PartialProof a) (ProofDL a))
+  -> SigmaE (ProofTag a) (Either (PartialProof a) (AtomicProof a))
   -> ByteString
-  -> Prove (SigmaE (ProofTag a) (ProofDL a))
+  -> Prove (SigmaE (ProofTag a) (AtomicProof a))
 generateProofs (Env env) expr0 message = goReal ch0 expr0
   where
     withChallenge ch tag = tag { proofTag'challenge = Just ch }
@@ -333,17 +346,32 @@ generateProofs (Env env) expr0 message = goReal ch0 expr0
     -- nodes and additionally responses at real leaves
     goReal ch = \case
       Leaf tag eProof -> case (proofTag'flag tag, eProof) of
-        (Real, (Left PartialProof{..})) -> do
-          let e = fromChallenge ch
-              [Secret sk] = [ secretKey | KeyPair{..} <- env
-                                        , pproofPK == publicKey
-                                        ]
-              z = pproofR .+. (sk .*. e)
-          return $ Leaf (ProofTag Real $ Just ch) $ ProofDL { publicK     = pproofPK
-                                    , commitmentA = pproofA
-                                    , challengeE  = ch
-                                    , responseZ   = z
-                                    }
+        (Real, (Left PartialProof{..})) -> case pproofInput of
+          InputDLog dlog -> do
+            let e = fromChallenge ch
+                [Secret sk] = [ secretKey | KeyPair{..} <- env
+                                          , dlog'publicKey dlog == publicKey
+                                          ]
+                z = pproofR .+. (sk .*. e)
+            return $ Leaf (ProofTag Real $ Just ch) $ ProofDL $ ProofDLog
+                                      { proofDLog'public = dlog
+                                      , proofDLog'commitmentA = fromGenerator pproofR
+                                      , proofDLog'challengeE  = ch
+                                      , proofDLog'responseZ   = z
+                                      }
+          InputDTuple dtuple -> do
+            let e = fromChallenge ch
+                [Secret sk] = [ secretKey | KeyPair{..} <- env
+                                          , dtuple'publicKeyA dtuple == publicKey
+                                          ]
+                z = pproofR .+. (sk .*. e)
+            return $ Leaf (ProofTag Real $ Just ch) $ ProofDT $ ProofDTuple
+                                      { proofDTuple'public = dtuple
+                                      , proofDTuple'commitmentA = (pproofR .*^ dtuple'generatorA dtuple, pproofR .*^ dtuple'generatorB dtuple)
+                                      , proofDTuple'challengeE  = ch
+                                      , proofDTuple'responseZ   = z
+                                      }
+
         (Simulated, Right e)   -> return $ Leaf (ProofTag Simulated $ Just ch) e
         _                      -> error $ "impossible happened in Sigma/Interpreter"
       AND tag es -> case proofTag'flag tag of
@@ -388,28 +416,35 @@ verifyProof proof message =
      checkProofs compTree
   && (checkHash (getVerifyRootChallenge compTree message))
   where
-    checkProofs :: SigmaE b (ProofDL a) -> Bool
-    checkProofs = getAll . foldMap (All . verifyProofDL)
+    checkProofs :: SigmaE b (AtomicProof a) -> Bool
+    checkProofs = getAll . foldMap (All . verifyAtomicProof)
 
     checkHash hash = proof'rootChallenge proof == hash
 
     compTree = completeProvenTree proof
 
 -- | Calculate all challenges for all nodes of a proof.
-completeProvenTree :: EC a => Proof a -> SigmaE () (ProofDL a)
+completeProvenTree :: EC a => Proof a -> SigmaE () (AtomicProof a)
 completeProvenTree Proof{..} = go proof'rootChallenge proof'tree
   where
     go ch tree = case tree of
-      ProvenLeaf resp pubKey  -> Leaf () $ getProofDL ch pubKey resp
+      ProvenLeaf resp proofInp -> Leaf () $ getAtomicProof ch proofInp resp
       ProvenOr leftmost rest -> OR   () $ toList $ fmap (\OrChild{..} -> go orChild'challenge orChild'tree) $
                                               (getLeftmostOrChallenge ch leftmost rest) Seq.<| rest
       ProvenAnd children      -> AND  () $ fmap (go ch) children
 
-    getProofDL ch pubKey respZ = ProofDL
-        { publicK     = pubKey
-        , commitmentA = getCommitment respZ ch pubKey
-        , responseZ   = respZ
-        , challengeE  = ch
+    getAtomicProof ch proofInp respZ = case proofInp of
+      InputDLog dlog -> ProofDL $ ProofDLog
+        { proofDLog'public      = dlog
+        , proofDLog'commitmentA = getCommitmentDLog respZ ch dlog
+        , proofDLog'responseZ   = respZ
+        , proofDLog'challengeE  = ch
+        }
+      InputDTuple dtuple -> ProofDT $ ProofDTuple
+        { proofDTuple'public      = dtuple
+        , proofDTuple'commitmentA = getCommitmentDTuple respZ ch dtuple
+        , proofDTuple'responseZ   = respZ
+        , proofDTuple'challengeE  = ch
         }
 
     getLeftmostOrChallenge ch leftmost children = OrChild

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
@@ -277,8 +277,8 @@ getChallenges expr0 message = goReal ch0 expr0
 
     extractCommitment =
       either
-        (\x -> FiatShamirLeaf (comResult'publicKey x) (comResult'commitment x))
-        (\x -> FiatShamirLeaf (publicK x)  (commitmentA x))
+        (\x -> FiatShamirLeaf (comResult'publicKey x)      (comResult'commitment x))
+        (\x -> FiatShamirLeaf (dlog'publicKey $ publicK x) (commitmentA x))
 
     withChallenge ch tag = tag { proofTag'challenge = Just ch }
 
@@ -331,8 +331,8 @@ data ResponseQuery a = ResponseQuery
   }
 
 queryToProofDL :: ResponseQuery a -> Maybe (ProofDL a)
-queryToProofDL ResponseQuery{..} = fmap (\resp -> ProofDL
-  { publicK     = responseQuery'publicKey
+queryToProofDL ResponseQuery{..} = fmap (\resp -> AtomicProof
+  { publicK     = DLog responseQuery'publicKey
   , commitmentA = responseQuery'commitment
   , responseZ   = resp
   , challengeE  = responseQuery'challenge

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
@@ -165,7 +165,7 @@ type CommitmentSecretExpr a = ProofExpr CommitmentSecret a
 
 data CommitmentQuery a
   = CommitmentQueryLog
-    { comQuery'publicLog     :: DLog a
+    { comQuery'publicLog     :: PublicKey a
     , comQuery'commitmentLog :: Maybe (Commitment a)
     }
   | CommitmentQueryTuple
@@ -180,7 +180,7 @@ data CommitmentSecret a = CommitmentSecret
 
 data CommitmentResult a
   = CommitmentResultLog
-    { comResult'publicLog     :: DLog a
+    { comResult'publicLog     :: PublicKey a
     , comResult'commitmentLog :: Commitment a
     }
   | CommitmentResultTuple

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/MultiSig.hs
@@ -215,7 +215,10 @@ queryCommitments knownKeys tree = fmap splitCommitmentAndSecret $ go tree
                               }
                             CommitmentQueryTuple{..} -> CommitmentSecret
                               { comSecret'query  = let dt = comQuery'publicTuple
-                                                   in  query { comQuery'commitmentTuple = Just (rnd .*^ dtuple'generatorA dt, rnd .*^ dtuple'generatorB dt) }
+                                                   in  query { comQuery'commitmentTuple = Just ( rnd .*^ dtuple'g   dt
+                                                                                               , rnd .*^ dtuple'g_x dt
+                                                                                               )
+                                                             }
                               , comSecret'secret = Just rnd
                               }
       -- if we do not own the key we just copy query (it's someone elses commitment) and leave secret blank

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
@@ -49,9 +49,10 @@ sexprAnn = \case
 -- | Set of known keys
 newtype Env a = Env { unEnv :: [KeyPair a] }
 
+-- | Public proof data (inputs for proof algorithms)
 data ProofInput a
-  = InputDLog (DLog a)
-  | InputDTuple (DTuple a)
+  = InputDLog (DLog a)      -- ^ proof of discrte log
+  | InputDTuple (DTuple a)  -- ^ proof of Diffie-Hellman tuple
   deriving (Generic)
 
 instance ByteRepr (ECPoint a) => ByteRepr (ProofInput a) where
@@ -110,10 +111,10 @@ instance ByteRepr (ECPoint a) => TH.Lift (ProofInput a) where
     where
       bs = encodeToBS pk
 
-
+-- | Proof of one of two methods of key verification
 data AtomicProof a
-  = ProofDL (ProofDLog a)
-  | ProofDT (ProofDTuple a)
+  = ProofDL (ProofDLog a)    -- ^ proof of knowledge of discrete log
+  | ProofDT (ProofDTuple a)  -- ^ proof of knowledge of Diffie-Helman tuple
   deriving (Generic)
 
 getProofInput :: AtomicProof a -> ProofInput a

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
@@ -51,7 +51,7 @@ newtype Env a = Env { unEnv :: [KeyPair a] }
 
 -- | Public proof data (inputs for proof algorithms)
 data ProofInput a
-  = InputDLog (DLog a)      -- ^ proof of discrte log
+  = InputDLog   (PublicKey a)      -- ^ proof of discrte log
   | InputDTuple (DTuple a)  -- ^ proof of Diffie-Hellman tuple
   deriving (Generic)
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
@@ -1,9 +1,23 @@
 -- | Types and functions for sigma-protocol.
-module Hschain.Utxo.Lang.Sigma.Protocol
-where
+module Hschain.Utxo.Lang.Sigma.Protocol(
+    SigmaE(..)
+  , sexprAnn
+  , Env(..)
+  , AtomicProof(..)
+  , ProofInput(..)
+  , simulateAtomicProof
+  , verifyAtomicProof
+  , responseZ
+  , getProofInput
+) where
 
+import Data.Aeson   (FromJSON,ToJSON)
 import GHC.Generics (Generic)
 
+import HSChain.Crypto.Classes (ByteRepr(..))
+
+import Hschain.Utxo.Lang.Sigma.DLog
+import Hschain.Utxo.Lang.Sigma.DTuple
 import Hschain.Utxo.Lang.Sigma.EllipticCurve
 import Hschain.Utxo.Lang.Sigma.Types
 
@@ -29,47 +43,66 @@ sexprAnn = \case
 -- | Set of known keys
 newtype Env a = Env { unEnv :: [KeyPair a] }
 
--- | Proof of knowledge of discrete logarithm
-data ProofDL a = ProofDL
-  { publicK     :: PublicKey a
-  , commitmentA :: Commitment a
-  , responseZ   :: Response a
-  , challengeE  :: Challenge a
-  } deriving (Generic)
+data ProofInput a
+  = InputDLog (DLog a)
+  | InputDTuple (DTuple a)
+  deriving (Generic)
 
-deriving instance ( Show (ECPoint   a)
-                  , Show (ECScalar  a)
-                  , Show (Challenge a)
-                  ) => Show (ProofDL a)
+deriving instance ( Show (ECPoint a)
+                  , Show (ProofDTuple a)
+                  , Show (ProofDLog   a)
+                  ) => Show (ProofInput a)
 
-deriving instance ( Eq (ECPoint   a)
-                  , Eq (ECScalar  a)
-                  , Eq (Challenge a)
-                  ) => Eq (ProofDL a)
+deriving instance ( Eq (ECPoint a)
+                  , Eq (ProofDTuple a)
+                  , Eq (ProofDLog   a)
+                  ) => Eq (ProofInput a)
 
-instance ( CBOR.Serialise (ECPoint   a)
-         , CBOR.Serialise (ECScalar  a)
-         , CBOR.Serialise (Challenge a)
-         ) => CBOR.Serialise (ProofDL a)
+instance ( CBOR.Serialise (ECPoint a)
+         , CBOR.Serialise (ProofDTuple a)
+         , CBOR.Serialise (ProofDLog   a)
+         ) => CBOR.Serialise (ProofInput a)
+
+deriving newtype instance (ByteRepr (ECPoint a)) => ToJSON (ProofInput a)
+deriving newtype instance (ByteRepr (ECPoint a)) => FromJSON (ProofInput a)
+
+data AtomicProof a
+  = ProofDL (ProofDLog a)
+  | ProofDT (ProofDTuple a)
+  deriving (Generic)
+
+getProofInput :: AtomicProof a -> ProofInput a
+getProofInput = \case
+  ProofDL ProofDLog{..}   -> InputDLog   proofDLog'public
+  ProofDT ProofDTuple{..} -> InputDTuple proofDTuple'public
+
+responseZ :: AtomicProof a -> Response a
+responseZ = \case
+  ProofDL ProofDLog{..}   -> proofDLog'responseZ
+  ProofDT ProofDTuple{..} -> proofDTuple'responseZ
+
+deriving instance ( Show (ProofDTuple a)
+                  , Show (ProofDLog   a)
+                  ) => Show (AtomicProof a)
+
+deriving instance ( Eq (ProofDTuple a)
+                  , Eq (ProofDLog   a)
+                  ) => Eq (AtomicProof a)
+
+instance ( CBOR.Serialise (ProofDTuple a)
+         , CBOR.Serialise (ProofDLog a)
+         ) => CBOR.Serialise (AtomicProof a)
 
 
 -- | Simulate proof of posession of discrete logarithm for given
 -- challenge
-simulateProofDL :: EC a => PublicKey a -> Challenge a -> IO (ProofDL a)
-simulateProofDL pk e = do
-  z <- generateScalar
-  return ProofDL
-    { publicK     = pk
-    , commitmentA =  getCommitment z e pk
-    , responseZ   = z
-    , challengeE  = e
-    }
+simulateAtomicProof :: EC a => ProofInput a -> Challenge a -> IO (AtomicProof a)
+simulateAtomicProof inp e = case inp of
+  InputDLog dlog     -> fmap ProofDL $ simulateProofDLog dlog e
+  InputDTuple dtuple -> fmap ProofDT $ simulateProofDTuple dtuple e
 
-getCommitment :: EC a => Response a -> Challenge a -> PublicKey a -> Commitment a
-getCommitment z ch pk = fromGenerator z ^+^ negateP (fromChallenge ch .*^ unPublicKey pk)
-
-verifyProofDL :: (EC a) => ProofDL a -> Bool
-verifyProofDL ProofDL{..}
-  = fromGenerator responseZ == (commitmentA ^+^ (fromChallenge challengeE .*^ unPublicKey publicK))
-
+verifyAtomicProof :: (EC a) => AtomicProof a -> Bool
+verifyAtomicProof = \case
+  ProofDL dlog   -> verifyProofDLog dlog
+  ProofDT dtuple -> verifyProofDTuple dtuple
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Types.hs
@@ -69,6 +69,9 @@ generateKeyPair = do
   s <- generateSecretKey
   return $ KeyPair s (getPublicKey s)
 
+getCommitment :: EC a => Response a -> Challenge a -> PublicKey a -> Commitment a
+getCommitment z ch pk = fromGenerator z ^+^ negateP (fromChallenge ch .*^ unPublicKey pk)
+
 deriving instance Show (ECScalar a) => Show (Secret a)
 deriving instance Eq   (ECScalar a) => Eq   (Secret a)
 deriving instance Ord  (ECScalar a) => Ord  (Secret a)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Utils/ByteString.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Utils/ByteString.hs
@@ -86,7 +86,7 @@ instance IsTerm Bool where
     PrimVal (PrimBool b) -> Just b
     _                    -> Nothing
 
-instance IsTerm (Sigma PublicKey) where
+instance IsTerm (Sigma ProofInput) where
   termType = const SigmaT
 
   toTerm = PrimVal . PrimSigma

--- a/hschain-utxo-lang/test/TM/Tx/Sigma.hs
+++ b/hschain-utxo-lang/test/TM/Tx/Sigma.hs
@@ -18,7 +18,7 @@ tests = testGroup "sigma-protocols"
   ]
 
 -- | Inits transaction that is owned by alice and has correct proof.
-initTx :: IO (Tx, GTx (Sigma PublicKey) Box)
+initTx :: IO (Tx, GTx (Sigma ProofInput) Box)
 initTx = do
   aliceSecret <- newSecret
   let alicePubKey = getPublicKey aliceSecret

--- a/hschain-utxo-pow-node/app/CLI.hs
+++ b/hschain-utxo-pow-node/app/CLI.hs
@@ -103,7 +103,7 @@ parseSend = do
                                     ]
           , tx'outputs = V.fromList [
               Box { box'value  = amount
-                  , box'script = coreProgToScript $ EPrim $ PrimSigma $ Fix $ SigmaPk pk
+                  , box'script = coreProgToScript $ EPrim $ PrimSigma $ Fix $ SigmaPk $ dlogInput pk
                   , box'args   = mempty
                   }
               ]

--- a/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
@@ -8,7 +8,6 @@ import Control.Monad.Reader
 
 import Data.ByteString (ByteString)
 import Data.Int
-import Data.Fix
 import Data.String
 import System.Random
 
@@ -83,7 +82,7 @@ xorGame aliceGuess bobGuess = do
         { tx'inputs  = [
             BoxInputRef { boxInputRef'id      = bobGameBid
                         , boxInputRef'args    = toArgs @(ByteString, Int64) (secret, aliceGuess)
-                        , boxInputRef'proof   = Just $ Fix $ Sigma.SigmaPk pkAlice
+                        , boxInputRef'proof   = Just $ Sigma.dlogSigma pkAlice
                         , boxInputRef'sigs    = []
                         , boxInputRef'sigMask = SigAll
                         }
@@ -95,7 +94,7 @@ xorGame aliceGuess bobGuess = do
         { tx'inputs  = [
             BoxInputRef { boxInputRef'id      = bobGameBid
                         , boxInputRef'args    = toArgs @(ByteString, Int64) (secret, aliceGuess)
-                        , boxInputRef'proof   = Just $ Fix $ Sigma.SigmaPk pkBob
+                        , boxInputRef'proof   = Just $ Sigma.dlogSigma pkBob
                         , boxInputRef'sigs    = []
                         , boxInputRef'sigMask = SigAll
                         }

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Monad.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Monad.hs
@@ -184,7 +184,7 @@ getState = call C.getState
 getBoxChainEnv :: App Env
 getBoxChainEnv = fmap unGetEnvResponse $ call C.getEnv
 
-getTxSigma :: Tx -> App (Either Text (Vector (Sigma PublicKey)))
+getTxSigma :: Tx -> App (Either Text (Vector (Sigma ProofInput)))
 getTxSigma tx = do
   resp <- call $ C.getTxSigma tx
   logTest $ T.unlines ["PRE TX SIGMA:", showt resp]

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Channel.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Channel.hs
@@ -88,7 +88,7 @@ data PlayerEnv = PlayerEnv
   -- ^ partner's public key
   , playerEnv'commonBoxId   :: !BoxId
   -- ^ shared boxId with initial balance
-  , playerEnv'commonScript  :: !(Sigma PublicKey)
+  , playerEnv'commonScript  :: !(Sigma ProofInput)
   -- ^ common sigma expression that guards shared balance box
   , playerEnv'revoceProc    :: !RevoceProc
   }
@@ -373,7 +373,7 @@ extractRevoceBox p secret = do
 
 
 
-newGame :: BoxId -> Sigma PublicKey -> Balance -> Wallet -> Wallet -> App Game
+newGame :: BoxId -> Sigma ProofInput -> Balance -> Wallet -> Wallet -> App Game
 newGame commonBoxId commonScript balance alice bob = do
   alicePlayer <- newPlayer commonBoxId commonScript balance alice (getWalletPublicKey bob)
   bobPlayer   <- newPlayer commonBoxId commonScript balance bob   (getWalletPublicKey alice)
@@ -382,7 +382,7 @@ newGame commonBoxId commonScript balance alice bob = do
     , game'bob   = bobPlayer
     }
 
-newPlayer :: BoxId -> Sigma PublicKey -> Balance -> Wallet -> PublicKey -> App Player
+newPlayer :: BoxId -> Sigma ProofInput -> Balance -> Wallet -> PublicKey -> App Player
 newPlayer commonBoxId commonScript balance wallet partnerPubKey = do
   proc <- newRevoceProc wallet
   player <- liftIO $ do

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/MultiSig.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/MultiSig.hs
@@ -51,7 +51,7 @@ multiSigExchange = do
     bobShareValue   = 6
 
 
-getSharedBoxTx :: Wallet -> Wallet -> (Int64, Int64) -> (Int64, Int64) -> BoxId -> BoxId -> App (Tx, BoxId, Sigma PublicKey)
+getSharedBoxTx :: Wallet -> Wallet -> (Int64, Int64) -> (Int64, Int64) -> BoxId -> BoxId -> App (Tx, BoxId, Sigma ProofInput)
 getSharedBoxTx alice bob (aliceValue, aliceChange) (bobValue, bobChange) aliceBox bobBox = liftIO $ do
   aliceProof <- fmap eitherToMaybe $ newProof aliceEnv (singleOwnerSigmaExpr alice) message
   bobProof   <- fmap eitherToMaybe $ newProof bobEnv   (singleOwnerSigmaExpr bob)   message
@@ -83,7 +83,7 @@ getSharedBoxTx alice bob (aliceValue, aliceChange) (bobValue, bobChange) aliceBo
       , box'args   = mempty
       }
 
-    commonScript = sigmaPk alicePk &&* sigmaPk bobPk
+    commonScript = dlogSigma alicePk &&* dlogSigma bobPk
 
     alicePk = getWalletPublicKey alice
     bobPk   = getWalletPublicKey bob
@@ -128,7 +128,7 @@ spendCommonBoxTx alice bob commonBoxId (aliceValue, bobValue) = liftIO $ do
       , boxInputRef'sigMask = SigAll
       }
 
-    commonScript = sigmaPk alicePk &&* sigmaPk bobPk
+    commonScript = dlogSigma alicePk &&* dlogSigma bobPk
 
     aliceBox = singleSpendBox aliceValue alicePk
     bobBox   = singleSpendBox bobValue   bobPk


### PR DESCRIPTION
Implements functions and primitives to proof Diffie-Hellman tuples (pairs of public keys).
This allows to implement ErgoMix script.

Instead of single primitive for proof of discrete logarithm we have two primitives.
Thus we use ```Sigma ProofInput``` to unite the primitives in place of single ```Sigma PublicKey```.
Proof of key ownership is ```DLog```.
Proof of pair of keys is ```DTuple```. 

There is boilerplate in Sigma interpreter module that was caused by difference in commitments for 
those two types of proofs. First requires single commitment ad second one requires two commitments.