### PR TITLE
Repl let pattern bind

### DIFF
--- a/hschain-utxo-repl/src/Hschain/Utxo/Repl.hs
+++ b/hschain-utxo-repl/src/Hschain/Utxo/Repl.hs
@@ -33,7 +33,7 @@ eval input = either (liftIO . putStrLn) evalInput $ parseInput input
 evalInput :: ParseRes -> Repl ()
 evalInput = \case
   ParseExpr expr     -> evalExpr expr
-  ParseBind var expr -> evalBind var expr
+  ParseBind bind     -> evalBind bind
   ParseCmd cmd args  -> evalCmd cmd args
   ParseErr loc err   -> showParseError loc err
 

--- a/hschain-utxo-repl/src/Hschain/Utxo/Repl/Cmd.hs
+++ b/hschain-utxo-repl/src/Hschain/Utxo/Repl/Cmd.hs
@@ -96,7 +96,7 @@ loadScript file = do
 
 resetEvalCtx :: Repl ()
 resetEvalCtx = modify' $ \st ->
-  st { replEnv'closure   = []
+  st { replEnv'closure   = mempty
      , replEnv'words     = [] }
 
 loadTx :: FilePath -> Repl ()

--- a/hschain-utxo-repl/test/TM/Repl.hs
+++ b/hschain-utxo-repl/test/TM/Repl.hs
@@ -19,6 +19,7 @@ tests = testGroup "repl"
   , testReplOk   "boolean ops"  boolOps
   , testReplOk   "sigma ops"  sigmaOps
   , testReplOk   "bytestring literals" bytesLiterals
+  , testReplOk   "LHS patterns" lhsPatBinds
   , testReplFail "add num and string" addNumAndText
   , testReplFail "var not in scope" varNotInScope
   ]
@@ -62,6 +63,12 @@ tests = testGroup "repl"
       [ "q = bytes \"asdf\""
       , "sha256 q"
       , "lengthBytes q"
+      ]
+
+    lhsPatBinds =
+      [ "q = (1, 2)"
+      , "(r, t) = q"
+      , "r + t"
       ]
 
 testReplOk :: String -> [String] -> TestTree


### PR DESCRIPTION
Implements LHS pattern binds for repl.

It becomes possible to write in REPL:

```
> q = (1, 2)
> (a, b) = q
> a + b
```