### PR TITLE
Check user type declaration

### DIFF
--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Const.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Const.hs
@@ -70,11 +70,15 @@ module Hschain.Utxo.Lang.Const(
   , checkMultiSig
   -- * Evaluation constants
   , evalReductionLimit
+  , reservedNames
 ) where
 
 import Prelude hiding (map, filter, foldr, foldl, length, show, all, any, and, or, sum, product, negate)
 import Data.String
+import Data.Set (Set)
 import Data.Text (Text)
+
+import qualified Data.Set as S
 
 negate :: IsString a => a
 negate = "negate"
@@ -207,5 +211,9 @@ checkMultiSig = "checkMultiSig"
 evalReductionLimit :: Int
 evalReductionLimit = 10000
 
+reservedNames :: Set Text
+reservedNames = S.fromList
+  [ "if", "then", "else", "where", "let", "in", "import"
+  , "module", "data", "type", "otherwise" ]
 
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
@@ -21,6 +21,7 @@ data Error
   = ParseError Loc Text             -- ^ parse errors
   | ExecError ExecError             -- ^ errors of execution
   | TypeError TypeError             -- ^ type-errors
+  | TypeDeclError TypeDeclError     -- ^ user type declaration error
   | PatError PatError               -- ^ pattern definition errors
   | InternalError InternalError     -- ^ errors of this type should not happen in production
   | MonoError MonoError             -- ^ errors during monomorphizing
@@ -81,6 +82,21 @@ data CoreScriptError
   | TypeCoreError TypeCoreError
   deriving stock    (Show,Eq,Generic,Data)
   deriving anyclass (NFData)
+
+-- | Error of user type declarations
+data TypeDeclError
+  = TypeIsDefined VarName VarName
+  | ConsIsDefined ConsName VarName
+  | RecFieldIsDefined VarName ConsName
+  | TypeIsNotDefined VarName
+  | TypeAppError Type KindError
+  deriving stock    (Show,Eq,Generic,Data)
+
+data KindError = KindError
+  { kindError'expected :: Int
+  , kindError'got      :: Int
+  }
+  deriving stock    (Show,Eq,Generic,Data)
 
 typeCoreMismatch :: MonadError TypeCoreError m => TypeCore -> TypeCore -> m a
 typeCoreMismatch ta tb = throwError $ TypeCoreMismatch ta tb

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Error.hs
@@ -85,13 +85,43 @@ data CoreScriptError
 
 -- | Error of user type declarations
 data TypeDeclError
-  = TypeIsDefined VarName VarName
-  | ConsIsDefined ConsName VarName
-  | RecFieldIsDefined VarName ConsName
-  | TypeIsNotDefined VarName
-  | TypeAppError Type KindError
+  = TypeIsDefined
+      { typeDeclError'userType    :: VarName
+      , typeDeclError'definedType :: VarName
+      }
+    -- ^ User type is already defined
+  | ConsDeclError
+      { typeDeclError'userType    :: VarName
+      , typeDeclError'userCons    :: ConsName
+      , typeDeclError'error       :: ConsDeclError
+      }
   deriving stock    (Show,Eq,Generic,Data)
 
+data ConsDeclError
+  = ConsIsDefined { consDeclError'definedType :: VarName }
+    -- ^ constructor name is already defined in another type
+  | RecFieldIsDefinedInCons
+      { consDeclError'userField   :: VarName
+      , consDeclError'definedCons :: ConsName
+      }
+    -- ^ record field is already defined in another constructor
+  | RecFieldIsDefinedAsValue
+      { consDeclError'userField    :: VarName
+      }
+    -- ^ record field is already defined as value
+  | RecFieldIsReservedName
+      { consDeclError'userField    :: VarName }
+    -- ^ record field name is a reserved name
+  | TypeArgIsNotDefined { consDeclError'typeArg     :: VarName }
+    -- ^ Type argument in the constructor is not defined
+  | TypeAppError
+      { consDeclError'typeArg     :: VarName
+      , consDeclError'kinds       :: KindError
+      }
+    -- ^ Wrong type application in the constructor
+  deriving stock    (Show,Eq,Generic,Data)
+
+-- | Error of type application when knids of types does not match.
 data KindError = KindError
   { kindError'expected :: Int
   , kindError'got      :: Int

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Exec/Module.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Exec/Module.hs
@@ -110,7 +110,10 @@ checkUserTypes definedVals uts = L.foldl' (<|>) Nothing $ fmap checkSubgroup typ
       where
         go (groups, approvedTypes) ty = ((ty, approvedTypes) : groups, ty : approvedTypes)
 
-    checkSubgroup (ty, approved) = checkUserTypeInCtx definedVals (toUserTypeCtx approved) ty
+    checkSubgroup (ty, approved) = checkUserTypeInCtx definedVals (toUserTypeCtxNoBase approved) ty
+
+    toUserTypeCtxNoBase typeDecls =
+      setupUserTypeInfo $ (\ts -> UserTypeCtx ts mempty mempty mempty mempty) $ M.fromList $ fmap (\x -> (userType'name x, x)) typeDecls
 
 -- | Convert raw module data to context information that can be used
 -- to evaluate expressions that depend on this module.

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/FromHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Parser/Hask/FromHask.hs
@@ -285,6 +285,7 @@ toName = \case
 fromQName :: H.QName Loc -> ParseResult VarName
 fromQName = \case
   H.UnQual _ name -> return $ toName name
+  H.Special _ (H.UnitCon loc) -> return $ VarName loc "()"
   other           -> parseFailedBy "Unexpected name" other
 
 fromQualType :: H.Type Loc -> ParseResult Signature

--- a/hschain-utxo-repl/src/Hschain/Utxo/Repl/Eval.hs
+++ b/hschain-utxo-repl/src/Hschain/Utxo/Repl/Eval.hs
@@ -34,6 +34,7 @@ import Safe
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Sequence as S
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Vector as V
@@ -158,7 +159,8 @@ parseBind input = fmap ParseBind $ fromParseResult $ onRepl P.parseBind input
 evalUserType :: UserType -> Repl ()
 evalUserType ut = do
   prevClosure <- gets replEnv'typeClosure
-  case checkUserTypeInCtx (fromTypeClosure prevClosure) ut of
+  definedValues <- fmap (Set.fromList . fmap (VarName noLoc) . getEnvWords) get
+  case checkUserTypeInCtx definedValues (fromTypeClosure prevClosure) ut of
     Nothing  -> do
       modify' $ \st -> st
         { replEnv'typeClosure = insertTypeClosure ut prevClosure

--- a/hschain-utxo-repl/test/TM/Repl.hs
+++ b/hschain-utxo-repl/test/TM/Repl.hs
@@ -23,6 +23,9 @@ tests = testGroup "repl"
   , testReplOk   "User defined data deckaration" dataDecls
   , testReplFail "add num and string" addNumAndText
   , testReplFail "var not in scope" varNotInScope
+  , testReplFail "type is not defined" typeIsNotDefined
+  , testReplFail "wrong kinds" wrongKinds1
+  , testReplFail "wrong kinds" wrongKinds2
   ]
   where
     numOps =
@@ -78,6 +81,18 @@ tests = testGroup "repl"
       , ":t Rgb"
       , "f x = Rgb 1 2 x"
       , "Q (f 1)"
+      ]
+
+    typeIsNotDefined =
+      [ "data Color = Rgb Int Int Intt"
+      ]
+
+    wrongKinds1 =
+      [ "data T = A | B (Maybe Int Text)"
+      ]
+
+    wrongKinds2 =
+      [ "data T = A | B (Int Text)"
       ]
 
 testReplOk :: String -> [String] -> TestTree

--- a/hschain-utxo-repl/test/TM/Repl.hs
+++ b/hschain-utxo-repl/test/TM/Repl.hs
@@ -26,6 +26,7 @@ tests = testGroup "repl"
   , testReplFail "type is not defined" typeIsNotDefined
   , testReplFail "wrong kinds" wrongKinds1
   , testReplFail "wrong kinds" wrongKinds2
+  , testReplOk   "unit as argument of constructor" unitConsArg
   ]
   where
     numOps =
@@ -93,6 +94,11 @@ tests = testGroup "repl"
 
     wrongKinds2 =
       [ "data T = A | B (Int Text)"
+      ]
+
+    unitConsArg =
+      [ "data F = F () Int"
+      , "q = F () 10"
       ]
 
 testReplOk :: String -> [String] -> TestTree

--- a/todo
+++ b/todo
@@ -1,8 +1,4 @@
-* Check user types
-
-   * () - unexpected value
-       
-      > data F = F ()  -- produces error
+* Update REPL words on erasure of definitions or user-types
 
 * Implement typical Bitcoin scenarios
 

--- a/todo
+++ b/todo
@@ -1,3 +1,9 @@
+* Check user types
+
+   * () - unexpected value
+       
+      > data F = F ()  -- produces error
+
 * Implement typical Bitcoin scenarios
 
 1. Оплата на хеш от адреса


### PR DESCRIPTION
Checks user-defined types for various types of errors.

Things that are checked:

* Type is already defined
* Constructor name is already defined
* Record-field name is already defined
* Type-argument of constructor is not defined
* Type-argument of xonstructor has wrong kind (takes wrong number of arguments) 
* 