### PR TITLE
Minimal cleanup of sigma expression

### DIFF
--- a/hschain-utxo-compiler/hschain-utxo-compiler.cabal
+++ b/hschain-utxo-compiler/hschain-utxo-compiler.cabal
@@ -25,6 +25,7 @@ library
                      , aeson
                      , bytestring
                      , hschain-utxo-lang
+                     , hschain-crypto
                      , optparse-applicative
                      , serialise
                      , text

--- a/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
+++ b/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
@@ -23,6 +23,7 @@ import Hschain.Utxo.Lang.Pretty
 import Hschain.Utxo.Lang.Infer
 import Hschain.Utxo.Lang.Lib.Base
 
+import HSChain.Crypto (encodeBase58)
 import qualified Hschain.Utxo.Lang.Sigma as Sigma
 
 import qualified Codec.Serialise as S
@@ -86,7 +87,7 @@ getPublicKey input output = do
   eSecret <- fmap S.deserialiseOrFail $ LB.readFile input
   either (const failToReadInput) onSecret eSecret
   where
-    onSecret secret = saveKey output $ Sigma.publicKeyToText $ Sigma.getPublicKey secret
+    onSecret secret = saveKey output $ encodeBase58 $ Sigma.getPublicKey secret
 
     failToReadInput = failToRead "secret" input
 

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Compile/Hask/Utils.hs
@@ -57,8 +57,8 @@ toSigma loc = foldFix $ \case
     toQOp op = H.QVarOp loc (toQName $ VarName loc op)
 
     fromProofInput = \case
-      Sigma.InputDLog   pk -> app loc "pk" [toText loc $ publicKeyToText pk]
-      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . publicKeyToText)
+      Sigma.InputDLog   pk -> app loc "pk" [toText loc $ encodeBase58 pk]
+      Sigma.InputDTuple dt -> app loc "proofDTuple" $ fmap (toText loc . encodeBase58)
         [ Sigma.dtuple'g    dt
         , Sigma.dtuple'g_x  dt
         , Sigma.dtuple'g_y  dt

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -249,9 +249,9 @@ toSigmaExpr :: Sigma a -> Either Bool (Sigma.SigmaE () a)
 toSigmaExpr a = (maybe (Left False) Right . toPrimSigmaExpr) =<< eliminateSigmaBool a
 
 toSigmaExprOrFail :: Sigma a -> Either Text (Sigma.SigmaE () a)
-toSigmaExprOrFail a = bimap catchBoolean id $ toSigmaExpr a
-  where
-    catchBoolean = const "Expression is constant boolean. It is not  a sigma-expression"
+toSigmaExprOrFail
+  = first (const "Expression is constant boolean. It is not  a sigma-expression")
+  . toSigmaExpr
 
 toPrimSigmaExpr :: Sigma a -> Maybe (Sigma.SigmaE () a)
 toPrimSigmaExpr = foldFix $ \case

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -62,11 +62,9 @@ import Data.ByteString (ByteString)
 import Data.Boolean
 import Data.Bifunctor
 import Data.Data
-import Data.Default
 import Data.Either
 import Data.Fix
 import Data.Functor.Classes (Eq1(..))
-import Data.Maybe
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Eq.Deriving
@@ -118,9 +116,6 @@ newtype SigMessage = SigMessage (Hash SHA256)
   deriving stock    (Generic)
   deriving anyclass (Serialise)
   deriving (ToJSON, FromJSON, ToJSONKey, FromJSONKey) via (ViaBase58 "SigMessage" ByteString)
-
-instance Default SigMessage where
-  def = fromJust $ decodeFromBS ""
 
 -- | Generate new private key.
 newSecret :: IO Secret

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -23,8 +23,6 @@ module Hschain.Utxo.Lang.Sigma(
   , SigmaF(..)
   , newProof
   , verifyProof
-  , publicKeyFromText
-  , publicKeyToText
   , emptyProofEnv
   , proofEnvFromKeys
   , newSecret
@@ -142,14 +140,6 @@ getPublicKey = Sigma.getPublicKey
 -- | Proof environment is a listavailable key-pairs.
 toProofEnv :: [KeyPair] -> ProofEnv
 toProofEnv ks = Sigma.Env ks
-
--- | Parse public key from text.
-publicKeyFromText :: Text -> Maybe PublicKey
-publicKeyFromText = serialiseFromText
-
--- | Convert public key to text.
-publicKeyToText :: PublicKey -> Text
-publicKeyToText = serialiseToText
 
 instance Serialise a => ToJSON (Sigma a) where
   toJSON = serialiseToJSON

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -23,7 +23,6 @@ module Hschain.Utxo.Lang.Sigma(
   , SigmaF(..)
   , newProof
   , verifyProof
-  , emptyProofEnv
   , proofEnvFromKeys
   , newSecret
   , newKeyPair
@@ -259,10 +258,6 @@ toPrimSigmaExpr = foldFix $ \case
   SigmaAnd as  -> fmap (Sigma.AND ()) $ sequence as
   SigmaOr  as  -> fmap (Sigma.OR  ()) $ sequence as
   SigmaBool _  -> Nothing
-
--- | Empty proof environment. It holds no keys.
-emptyProofEnv :: ProofEnv
-emptyProofEnv = Sigma.Env []
 
 -- | Wrapper to contruct proof environment from list of key-pairs.
 proofEnvFromKeys :: [KeyPair] -> ProofEnv


### PR DESCRIPTION
- Default instance for SigMessage is dropped
- hschain-crypto is used to convert keys to text for pretty-printing purposes
- other minimal changes