### PR TITLE
Use SigmaE instead of Fix SigmaF

### DIFF
--- a/hschain-utxo-api/hschain-utxo-api-rest/src/Hschain/Utxo/API/Rest.hs
+++ b/hschain-utxo-api/hschain-utxo-api-rest/src/Hschain/Utxo/API/Rest.hs
@@ -82,9 +82,11 @@ data PostTxResponse = PostTxResponse
 
 -- | Result of execution of TX in the current state of blockchain.
 data SigmaTxResponse = SigmaTxResponse
-  { sigmaTxResponse'value :: !(Either Text (Vector BoolExprResult))  -- ^ result of execution
-                                                                     -- (sigma-expression or boolean)
-  , sigmaTxResponse'debug :: !Text }                                 -- ^ Debug info on the process of execution
+  { sigmaTxResponse'value :: !(Either Text (Vector ScriptEvalResult))
+    -- ^ result of execution (sigma-expression or boolean)
+  , sigmaTxResponse'debug :: !Text
+    -- ^ Debug info on the process of execution
+  }
   deriving (Show, Eq)
 
 -- | Useful stats about state of the blockchain

--- a/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
+++ b/hschain-utxo-compiler/src/Hschain/Utxo/Compiler/Commands.hs
@@ -120,7 +120,7 @@ signSigma secretFile exprFile txFile output = do
       file <- LB.readFile secretFile
       return $ either (const failToReadSecret) id $ S.deserialiseOrFail file
 
-    readExpr :: IO BoolExprResult
+    readExpr :: IO ScriptEvalResult
     readExpr = do
       file <- LB.readFile exprFile
       return $ fromMaybe failToReadExpression $ decode' file

--- a/hschain-utxo-lang/hschain-utxo-lang.cabal
+++ b/hschain-utxo-lang/hschain-utxo-lang.cabal
@@ -84,7 +84,6 @@ library
                      , hschain-crypto
                      , aeson
                      , array
-                     , Boolean
                      , base64-bytestring
                      , base58-bytestring
                      , bytestring

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Build.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/Compile/Build.hs
@@ -30,7 +30,6 @@ module Hschain.Utxo.Lang.Core.Compile.Build(
 
 import Data.ByteString (ByteString)
 import Data.Int
-import Data.Fix
 import Data.Text (Text)
 
 import Hschain.Utxo.Lang.Core.Compile.Expr
@@ -63,7 +62,7 @@ bytes :: ByteString -> Core v
 bytes b = EPrim $ PrimBytes b
 
 sigmaBool :: Bool -> Core v
-sigmaBool b = EPrim $ PrimSigma $ Fix $ SigmaBool b
+sigmaBool b = EPrim $ PrimSigma $ Leaf () $ Left b
 
 equals :: TypeCore -> Core v -> Core v -> Core v
 equals t a b = ap (EPrimOp (OpEQ t)) [a, b]

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/RefEval.hs
@@ -18,7 +18,6 @@ import Data.ByteString (ByteString)
 import Data.Bool
 import Data.Text       (Text)
 import Data.Typeable
-import Data.Fix
 import Data.Foldable (foldrM)
 import Data.Vector.Generic ((!?))
 import qualified Data.Vector          as V
@@ -183,21 +182,23 @@ evalPrimOp env = \case
       False -> match y
   OpBoolNot -> pure $ lift1 not
   --
-  OpSigBool   -> pure $ lift1 $ Fix . SigmaBool
-  OpSigAnd    -> pure $ lift2 $ \a b -> Fix $ SigmaAnd [a,b]
-  OpSigOr     -> pure $ lift2 $ \a b -> Fix $ SigmaOr  [a,b]
-  OpSigPK     -> pure $ evalLift1 $ \t -> fmap (Fix . SigmaPk . dlogInput) $ parsePublicKey t
-  OpSigDTuple -> pure $ evalLift3 $ \genB keyA keyB -> liftA3 (\gB pkA pkB -> Fix $ SigmaPk $ dtupleInput gB pkA pkB) (parseGenerator genB) (parsePublicKey keyA) (parsePublicKey keyB)
-  OpSigListAnd   -> pure $ lift1 $ Fix . SigmaAnd
-  OpSigListOr    -> pure $ lift1 $ Fix . SigmaOr
+  OpSigBool   -> pure $ lift1 $ Leaf () . Left
+  OpSigAnd    -> pure $ lift2 $ \a b -> AND () [a,b]
+  OpSigOr     -> pure $ lift2 $ \a b -> OR  () [a,b]
+  OpSigPK     -> pure $ evalLift1 $ \t -> fmap (sigmaPk . dlogInput) $ parsePublicKey t
+  OpSigDTuple -> pure $ evalLift3 $ \genB keyA keyB ->
+    liftA3 (\gB pkA pkB -> sigmaPk $ dtupleInput gB pkA pkB)
+           (parseGenerator genB) (parsePublicKey keyA) (parsePublicKey keyB)
+  OpSigListAnd   -> pure $ lift1 $ AND ()
+  OpSigListOr    -> pure $ lift1 $ OR  ()
   OpSigListAll _ -> pure $ Val2F $ \valF valXS -> fmap inj $ do
     f  <- match @(Val -> Eval Val) valF
     xs <- match @[Val]        valXS
-    fmap (Fix . SigmaAnd) $ mapM (match <=< f) xs
+    AND () <$> mapM (match <=< f) xs
   OpSigListAny _ -> pure $ Val2F $ \valF valXS -> fmap inj $ do
     f  <- match @(Val -> Eval Val) valF
     xs <- match @[Val]        valXS
-    fmap (Fix . SigmaOr) $ mapM (match <=< f) xs
+    OR () <$> mapM (match <=< f) xs
   --
   OpCheckSig -> pure $ evalLift2 $ \bs sigIndex -> do
     pk  <- parsePublicKey bs
@@ -382,7 +383,7 @@ instance MatchPrim LB.ByteString where
   match (ValP (PrimBytes a)) = pure $ LB.fromStrict a
   match _                    = throwError "Expecting Bytes"
 
-instance k ~ ProofInput => MatchPrim (Sigma k) where
+instance (k ~ (), a ~ Either Bool ProofInput) => MatchPrim (SigmaE k a) where
   match (ValP (PrimSigma a)) = pure a
   match _                    = throwError "Expecting Sigma"
 
@@ -414,7 +415,7 @@ instance InjPrim ByteString    where inj = ValP . PrimBytes
 instance InjPrim LB.ByteString where inj = inj . LB.toStrict
 instance InjPrim (Hash a)      where inj (Hash h) = inj h
 
-instance k ~ ProofInput => InjPrim (Sigma k) where
+instance (k ~ (), a ~ Either Bool ProofInput) => InjPrim (SigmaE k a) where
   inj = ValP . PrimSigma
 
 instance InjPrim a => InjPrim [a] where

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/ToHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/ToHask.hs
@@ -88,7 +88,7 @@ toHaskExprCore = flip evalState (T.pack <$> stringPrettyLetters) . go []
       PrimText txt  -> fromText txt
       PrimBytes bs  -> H.App () (H.Var () (toQName "bytes")) (fromText $ encodeBase58 bs)
       PrimBool b    -> fromBool b
-      PrimSigma sig -> fromSigma $ mapPk (BL.toStrict . CBOR.serialise) sig
+      PrimSigma sig -> fromSigma $ (fmap . fmap) (BL.toStrict . CBOR.serialise) sig
 
     fromText txt = H.Lit () $ H.String () str str
       where

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/ToHask.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Core/ToHask.hs
@@ -12,7 +12,6 @@ import Hex.Common.Text (showt)
 import qualified Codec.Serialise as CBOR
 import Control.Monad.State.Strict
 import Data.ByteString (ByteString)
-import Data.Fix
 import Data.String
 import Data.Void
 import Data.Text (Text)
@@ -98,14 +97,15 @@ toHaskExprCore = flip evalState (T.pack <$> stringPrettyLetters) . go []
     fromBool b = H.Con () $ if b then toQName "True" else toQName "False"
 
     fromSigma :: Sigma ByteString -> H.Exp ()
-    fromSigma = foldFix rec
+    fromSigma = rec
       where
         rec = \case
-          SigmaPk pkey -> let keyTxt = encodeBase58 pkey
-                          in  ap1 Const.pk $ lit $ H.String src (T.unpack keyTxt) (T.unpack keyTxt)
-          SigmaAnd as  -> foldl1 (ap2 Const.sigmaAnd) as
-          SigmaOr  as  -> foldl1 (ap2 Const.sigmaOr) as
-          SigmaBool b  -> fromBool b
+          Leaf _ (Right pkey) -> let keyTxt = encodeBase58 pkey
+                                 in  ap1 Const.pk $ lit $ H.String src (T.unpack keyTxt) (T.unpack keyTxt)
+          Leaf _ (Left  b)    -> fromBool b
+          AND  _ as  -> foldl1 (ap2 Const.sigmaAnd) $ rec <$> as
+          OR   _ as  -> foldl1 (ap2 Const.sigmaOr)  $ rec <$> as
+
 
         ap1 f a = H.App () (toVar f) a
         ap2 f a b = H.App src (H.App () (toVar f) a) b

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -63,6 +63,7 @@ import GHC.Generics
 import Text.Show.Deriving
 
 import HSChain.Crypto.Classes (ByteRepr(..))
+import qualified HSChain.Crypto as Crypto
 import Hschain.Utxo.Lang.Sigma
 import Hschain.Utxo.Lang.Types              (Script(..))
 import Hschain.Utxo.Lang.Core.Types         (Prim(..))
@@ -478,7 +479,7 @@ instance ToLang Text where
 instance ToLang ByteString where
   toLang loc bs = toPrim loc $ PrimBytes bs
 
-instance ToLang PublicKey where
+instance (a ~ CryptoAlg) => ToLang (Crypto.PublicKey a) where
   toLang loc key = toPrim loc $ PrimBytes $ encodeToBS key
 
 instance ToLang Script where

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Expr.hs
@@ -31,7 +31,7 @@ module Hschain.Utxo.Lang.Expr(
   , bindAlts
   , getBindsNames
   , secretVar
-  , BoolExprResult(..)
+  , ScriptEvalResult(..)
   , mapDeclsM
   , fromParserLoc
   , emptyTypeContext
@@ -278,17 +278,17 @@ secretVar = flip mappend "___"
 
 -- | Result of the script can be boolean constant or sigma-expression
 -- that user have to prove.
-data BoolExprResult
-  = ConstBool Bool
-  | SigmaResult (Sigma ProofInput)
+data ScriptEvalResult
+  = ConstBool   !Bool
+  | SigmaResult !(SigmaE () ProofInput)
   deriving (Show, Eq)
 
-instance ToJSON BoolExprResult where
+instance ToJSON ScriptEvalResult where
   toJSON = \case
     ConstBool b -> object ["bool"  .= b]
     SigmaResult s -> object ["sigma" .= s]
 
-instance FromJSON BoolExprResult where
+instance FromJSON ScriptEvalResult where
   parseJSON = withObject "BoolExprResult" $ \obj ->
         (ConstBool <$> obj .: "bool")
     <|> (SigmaResult <$> obj .: "sigma")

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Pretty.hs
@@ -11,7 +11,6 @@ import Codec.Serialise (deserialiseOrFail)
 import Hex.Common.Serialise
 
 import Data.Bool
-import Data.Fix
 import Data.Void
 import Data.ByteString.Lazy (fromStrict)
 import Data.Text (Text)
@@ -164,12 +163,12 @@ instance Pretty Env where
 instance Pretty Proof where
   pretty proof = pretty $ P.ppShow proof
 
-instance Pretty a => Pretty (S.Sigma a) where
-  pretty = foldFix $ \case
-      S.SigmaPk k    -> parens $ hsep ["pk", pretty k]
-      S.SigmaAnd as  -> parens $ hsep $ Const.sigmaAnd : as
-      S.SigmaOr  as  -> parens $ hsep $ Const.sigmaOr  : as
-      S.SigmaBool b  -> "Sigma" <> pretty b
+instance Pretty a => Pretty (S.SigmaE () (Either Bool a)) where
+  pretty = \case
+    S.Leaf () (Right k) -> parens $ hsep ["pk", pretty k]
+    S.Leaf () (Left  b) -> "Sigma" <> pretty b
+    S.AND  () as        -> parens $ hsep $ Const.sigmaAnd : fmap pretty as
+    S.OR   () as        -> parens $ hsep $ Const.sigmaOr  : fmap pretty as
 
 instance Pretty S.ProofInput where
   pretty = \case

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -29,7 +29,6 @@ module Hschain.Utxo.Lang.Sigma(
   , toPublicKey
   , getKeyPair
   , toProofEnv
-  , equalSigmaExpr
   , equalSigmaProof
   , eliminateSigmaBool
   -- * Multi-signatures

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -54,7 +54,6 @@ import Codec.Serialise
 
 import Data.Aeson
 import Data.ByteString (ByteString)
-import Data.Boolean
 import Data.Bifunctor
 import Data.Either
 import Data.Functor.Classes (Eq1(..))
@@ -155,14 +154,6 @@ mapPk = fmap . fmap
 
 mapPkM :: Applicative m => (a -> m b) -> Sigma a -> m (Sigma b)
 mapPkM = traverse . traverse
-
-instance Boolean (Sigma k) where
-  true  = Sigma.Leaf () $ Left True
-  false = Sigma.Leaf () $ Left False
-
-  notB  = error "Not is not defined for Sigma-expressions"
-  (&&*) a b = Sigma.AND () [a, b]
-  (||*) a b = Sigma.OR  () [a, b]
 
 sigmaPk :: k -> Sigma k
 sigmaPk k = Sigma.Leaf () (Right k)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -15,12 +15,12 @@ module Hschain.Utxo.Lang.Sigma(
   , AtomicProof
   , SigMessage(..)
   , Sigma
+  , Sigma.SigmaE(..)
   , sigmaPk
   , dlogSigma
   , dtupleSigma
   , mapPk
   , mapPkM
-  , SigmaF(..)
   , newProof
   , verifyProof
   , proofEnvFromKeys
@@ -48,28 +48,20 @@ module Hschain.Utxo.Lang.Sigma(
   , getPublicKey
   ) where
 
-import Hex.Common.Serialise
-
 import Control.Monad.Except
-import Control.DeepSeq (NFData,NFData1)
+import Control.DeepSeq (NFData)
 import Codec.Serialise
 
 import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.Boolean
 import Data.Bifunctor
-import Data.Data
 import Data.Either
-import Data.Fix
 import Data.Functor.Classes (Eq1(..))
 import Data.Set (Set)
 import Data.Text (Text)
-import Data.Eq.Deriving
-import Data.Ord.Deriving
 
-import GHC.Generics (Generic, Generic1)
-
-import Text.Show.Deriving
+import GHC.Generics (Generic)
 
 import HSChain.Crypto.Classes      (ViaBase58(..), ByteRepr(..))
 import HSChain.Crypto.Classes.Hash
@@ -140,22 +132,13 @@ getPublicKey = Sigma.getPublicKey
 toProofEnv :: [KeyPair] -> ProofEnv
 toProofEnv ks = Sigma.Env ks
 
-instance Serialise a => ToJSON (Sigma a) where
-  toJSON = serialiseToJSON
-
-instance Serialise a => FromJSON (Sigma a) where
-  parseJSON = serialiseFromJSON
-
 -- | Creates proof for sigma expression with given collection of key-pairs (@ProofEnv@).
 -- The last argument message is a serialised content of transaction.
 -- It's message to be signed.
 --
 -- For the message use getTxBytes from TX that has no proof.
-newProof :: ProofEnv -> Sigma ProofInput -> SigMessage -> IO (Either Text Proof)
-newProof env expr message =
-  case toSigmaExprOrFail expr of
-    Right sigma -> Sigma.createProof env sigma $ encodeToBS message
-    Left  err   -> return $ Left err
+newProof :: ProofEnv -> Sigma.SigmaE () ProofInput -> SigMessage -> IO (Either Text Proof)
+newProof env expr message = Sigma.createProof env expr $ encodeToBS message
 
 -- | Verify the proof.
 --
@@ -165,116 +148,82 @@ newProof env expr message =
 verifyProof :: Proof -> SigMessage -> Bool
 verifyProof proof = Sigma.verifyProof proof . encodeToBS
 
-type Sigma k = Fix (SigmaF k)
+type Sigma k = Sigma.SigmaE () (Either Bool k)
 
 mapPk :: (a -> b) -> Sigma a -> Sigma b
-mapPk f = foldFix $ \case
-  SigmaPk a   -> Fix $ SigmaPk (f a)
-  SigmaAnd as -> Fix $ SigmaAnd as
-  SigmaOr  as -> Fix $ SigmaOr  as
-  SigmaBool b -> Fix $ SigmaBool b
+mapPk = fmap . fmap
 
-mapPkM :: Monad m => (a -> m b) -> Sigma a -> m (Sigma b)
-mapPkM f = foldFixM $ \case
-  SigmaPk a   -> fmap (Fix . SigmaPk) (f a)
-  SigmaAnd as -> pure $ Fix $ SigmaAnd as
-  SigmaOr  as -> pure $ Fix $ SigmaOr  as
-  SigmaBool b -> pure $ Fix $ SigmaBool b
+mapPkM :: Applicative m => (a -> m b) -> Sigma a -> m (Sigma b)
+mapPkM = traverse . traverse
 
 instance Boolean (Sigma k) where
-  true  = Fix $ SigmaBool True
-  false = Fix $ SigmaBool False
+  true  = Sigma.Leaf () $ Left True
+  false = Sigma.Leaf () $ Left False
 
   notB  = error "Not is not defined for Sigma-expressions"
-  (&&*) a b = Fix $ SigmaAnd [a, b]
-  (||*) a b = Fix $ SigmaOr [a, b]
+  (&&*) a b = Sigma.AND () [a, b]
+  (||*) a b = Sigma.OR  () [a, b]
 
 sigmaPk :: k -> Sigma k
-sigmaPk k = Fix $ SigmaPk k
+sigmaPk k = Sigma.Leaf () (Right k)
 
-dlogSigma :: PublicKey -> Sigma ProofInput
-dlogSigma k = sigmaPk $ dlogInput k
+dlogSigma :: PublicKey -> Sigma.SigmaE () ProofInput
+dlogSigma k = Sigma.Leaf () $ dlogInput k
 
-dtupleSigma :: ECPoint -> PublicKey -> PublicKey -> Sigma ProofInput
-dtupleSigma genB keyA keyB = sigmaPk $ dtupleInput genB keyA keyB
-
--- | Sigma-expression
-data SigmaF k a =
-    SigmaPk k      -- ownership of the key (contains public key)
-  | SigmaAnd [a]   -- and-expression
-  | SigmaOr  [a]   -- or-expression
-  | SigmaBool Bool -- wraps boolean constants
-  deriving stock (Functor, Foldable, Traversable, Show, Read, Eq, Ord, Generic, Generic1, Data)
-  deriving anyclass (NFData, NFData1, Serialise)
-
-instance Serialise k => Serialise (Fix (SigmaF k))
-
-instance (CryptoHashable k, CryptoHashable a) => CryptoHashable (SigmaF k a) where
-  hashStep = genericHashStep Sigma.hashDomain
-
-fromSigmaExpr :: Sigma.SigmaE () a -> Sigma a
-fromSigmaExpr = \case
-  Sigma.Leaf _ k -> Fix $ SigmaPk k
-  Sigma.AND _ as -> Fix $ SigmaAnd $ fmap rec as
-  Sigma.OR _ as  -> Fix $ SigmaOr  $ fmap rec as
-  where
-    rec  = fromSigmaExpr
+dtupleSigma :: ECPoint -> PublicKey -> PublicKey -> Sigma.SigmaE () ProofInput
+dtupleSigma genB keyA keyB = Sigma.Leaf () $ dtupleInput genB keyA keyB
 
 -- | Tries to remove all boolean constants.
 -- returns Left boolean if it's not possible
 -- to eliminate boolean constants.
-eliminateSigmaBool :: Sigma a -> Either Bool (Sigma a)
-eliminateSigmaBool = foldFix $ \case
-  SigmaBool b -> Left b
-  SigmaPk pk  -> Right $ Fix $ SigmaPk pk
-  SigmaAnd as
-    | and bools -> case sigmas of
-       []       -> Left True
-       [sigma]  -> Right sigma
-       _        -> Right $ Fix $ SigmaAnd sigmas
-    | otherwise -> Left False
-    where
-      (bools, sigmas) = partitionEithers as
-  SigmaOr as
-    | or bools  -> Left True
-    | otherwise -> case sigmas of
-        []      -> Left False
-        [sigma] -> Right sigma
-        _       -> Right $ Fix $ SigmaOr sigmas
-    where
-      (bools, sigmas) = partitionEithers as
+eliminateSigmaBool :: Sigma a -> Either Bool (Sigma.SigmaE () a)
+eliminateSigmaBool = go
+  where
+    go = \case
+      Sigma.Leaf _ (Left  b) -> Left b
+      Sigma.Leaf _ (Right a) -> Right $ Sigma.Leaf () a
+      Sigma.AND _ as
+        | and bools -> case sigmas of
+           []       -> Left True
+           [sigma]  -> Right sigma
+           _        -> Right $ Sigma.AND () sigmas
+        | otherwise -> Left False
+        where
+          (bools, sigmas) = partitionEithers $ eliminateSigmaBool <$> as
+      Sigma.OR () as
+        | or bools  -> Left True
+        | otherwise -> case sigmas of
+            []      -> Left False
+            [sigma] -> Right sigma
+            _       -> Right $ Sigma.OR () sigmas
+        where
+          (bools, sigmas) = partitionEithers $ eliminateSigmaBool <$> as
 
 toSigmaExpr :: Sigma a -> Either Bool (Sigma.SigmaE () a)
-toSigmaExpr a = (maybe (Left False) Right . toPrimSigmaExpr) =<< eliminateSigmaBool a
+toSigmaExpr = eliminateSigmaBool
 
 toSigmaExprOrFail :: Sigma a -> Either Text (Sigma.SigmaE () a)
 toSigmaExprOrFail
   = first (const "Expression is constant boolean. It is not  a sigma-expression")
   . toSigmaExpr
 
-toPrimSigmaExpr :: Sigma a -> Maybe (Sigma.SigmaE () a)
-toPrimSigmaExpr = foldFix $ \case
-  SigmaPk k    -> Just $ Sigma.Leaf () k
-  SigmaAnd as  -> fmap (Sigma.AND ()) $ sequence as
-  SigmaOr  as  -> fmap (Sigma.OR  ()) $ sequence as
-  SigmaBool _  -> Nothing
-
 -- | Wrapper to contruct proof environment from list of key-pairs.
 proofEnvFromKeys :: [KeyPair] -> ProofEnv
 proofEnvFromKeys = Sigma.Env
 
 -- | Check if sigma expression is proven with given proof.
-equalSigmaProof :: Sigma ProofInput -> Proof -> Bool
+equalSigmaProof :: Sigma.SigmaE () ProofInput -> Proof -> Bool
 equalSigmaProof candidate proof =
   equalSigmaExpr
       candidate
-      (fromSigmaExpr $ Sigma.completeProvenTree proof)
+      (Sigma.completeProvenTree proof)
 
-equalSigmaExpr :: Sigma ProofInput -> Sigma AtomicProof -> Bool
-equalSigmaExpr (Fix x) (Fix y) = case (x, y) of
-  (SigmaPk inp, SigmaPk proof)     -> inp == Sigma.getProofInput proof
-  (SigmaOr as, SigmaOr bs)         -> equalList as bs
-  (SigmaAnd as, SigmaAnd bs)       -> equalList as bs
+equalSigmaExpr :: Sigma.SigmaE () ProofInput -> Sigma.SigmaE () AtomicProof -> Bool
+equalSigmaExpr x y = case (x, y) of
+  (Sigma.Leaf _ inp, Sigma.Leaf _ proof)
+    -> inp == Sigma.getProofInput proof
+  (Sigma.OR  _ as, Sigma.OR  _ bs) -> equalList as bs
+  (Sigma.AND _ as, Sigma.AND _ bs) -> equalList as bs
   _                                -> False
   where
     equalList = liftEq equalSigmaExpr
@@ -414,7 +363,3 @@ dlogInput = Sigma.InputDLog
 dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
 dtupleInput genB keyA keyB =
   Sigma.InputDTuple $ Sigma.DTuple Sigma.groupGenerator genB keyA keyB
-
-$(deriveShow1 ''SigmaF)
-$(deriveEq1   ''SigmaF)
-$(deriveOrd1  ''SigmaF)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -165,7 +165,7 @@ dtupleInput genB keyA keyB =
 -- | Tries to remove all boolean constants.
 -- returns Left boolean if it's not possible
 -- to eliminate boolean constants.
-eliminateSigmaBool :: Sigma a -> Either Bool (Sigma.SigmaE () a)
+eliminateSigmaBool :: Sigma.SigmaE () (Either Bool a) -> Either Bool (Sigma.SigmaE () a)
 eliminateSigmaBool = go
   where
     go = \case

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -19,6 +19,8 @@ module Hschain.Utxo.Lang.Sigma(
   , sigmaPk
   , dlogSigma
   , dtupleSigma
+  , dlogInput
+  , dtupleInput
   , newProof
   , verifyProof
   , proofEnvFromKeys
@@ -40,8 +42,6 @@ module Hschain.Utxo.Lang.Sigma(
   , queryResponses
   , appendResponsesToProof
   , checkChallenges
-  , dlogInput
-  , dtupleInput
   , getSecretKey
   , getPublicKey
   ) where
@@ -154,6 +154,14 @@ dlogSigma k = Sigma.Leaf () $ dlogInput k
 
 dtupleSigma :: ECPoint -> PublicKey -> PublicKey -> Sigma.SigmaE () ProofInput
 dtupleSigma genB keyA keyB = Sigma.Leaf () $ dtupleInput genB keyA keyB
+
+dlogInput :: PublicKey -> ProofInput
+dlogInput = Sigma.InputDLog
+
+dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
+dtupleInput genB keyA keyB =
+  Sigma.InputDTuple $ Sigma.DTuple Sigma.groupGenerator genB keyA keyB
+
 
 -- | Tries to remove all boolean constants.
 -- returns Left boolean if it's not possible
@@ -330,10 +338,3 @@ appendResponsesToProof = Sigma.appendResponsesToProof
 checkChallenges :: Commitments -> Challenges -> SigMessage -> Bool
 checkChallenges commitments challenges message =
   Sigma.checkChallenges commitments challenges (encodeToBS message)
-
-dlogInput :: PublicKey -> ProofInput
-dlogInput = Sigma.InputDLog
-
-dtupleInput :: ECPoint -> PublicKey -> PublicKey -> ProofInput
-dtupleInput genB keyA keyB =
-  Sigma.InputDTuple $ Sigma.DTuple Sigma.groupGenerator genB keyA keyB

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma.hs
@@ -19,8 +19,6 @@ module Hschain.Utxo.Lang.Sigma(
   , sigmaPk
   , dlogSigma
   , dtupleSigma
-  , mapPk
-  , mapPkM
   , newProof
   , verifyProof
   , proofEnvFromKeys
@@ -147,12 +145,6 @@ verifyProof :: Proof -> SigMessage -> Bool
 verifyProof proof = Sigma.verifyProof proof . encodeToBS
 
 type Sigma k = Sigma.SigmaE () (Either Bool k)
-
-mapPk :: (a -> b) -> Sigma a -> Sigma b
-mapPk = fmap . fmap
-
-mapPkM :: Applicative m => (a -> m b) -> Sigma a -> m (Sigma b)
-mapPkM = traverse . traverse
 
 sigmaPk :: k -> Sigma k
 sigmaPk k = Sigma.Leaf () (Right k)

--- a/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
+++ b/hschain-utxo-lang/src/Hschain/Utxo/Lang/Sigma/Protocol.hs
@@ -46,8 +46,8 @@ data SigmaE k a
     -- ^ AND connective
   | OR  k [SigmaE k a]
     -- ^ OR connective
-  deriving stock    (Functor, Foldable, Traversable, Show, Eq, Generic)
-  deriving anyclass (Serialise)
+  deriving stock    (Functor,Foldable,Traversable,Show,Eq,Ord,Generic,Data)
+  deriving anyclass (Serialise,NFData)
 
 sexprAnn :: SigmaE k a -> k
 sexprAnn = \case
@@ -147,3 +147,6 @@ deriving instance (EC a) => Eq   (AtomicProof a)
 instance (EC a) => CBOR.Serialise (AtomicProof a)
 
 instance (CryptoAsymmetric a) => CBOR.Serialise (FiatShamirLeaf a)
+
+instance (ToJSON   k, ToJSON   a) => ToJSON   (SigmaE k a) where
+instance (FromJSON k, FromJSON a) => FromJSON (SigmaE k a) where

--- a/hschain-utxo-lang/test/TM/Core.hs
+++ b/hschain-utxo-lang/test/TM/Core.hs
@@ -1,7 +1,6 @@
 -- |
 module TM.Core ( tests )where
 
-import Data.Fix
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -17,7 +16,7 @@ tests :: TestTree
 tests = testGroup "core"
   [ testGroup "Literal"
     [ testProgram nm (progLiteral p) p
-    | (nm,p) <- [ ("sigma", PrimSigma $ Fix $ SigmaBool True)
+    | (nm,p) <- [ ("sigma", PrimSigma $ Leaf () $ Left True)
                 , ("bool" , PrimBool False)
                 , ("int",   PrimInt  123)
                 , ("text",  PrimText "XX")

--- a/hschain-utxo-lang/test/TM/Core/List.hs
+++ b/hschain-utxo-lang/test/TM/Core/List.hs
@@ -9,7 +9,6 @@ module TM.Core.List(
   , withBigList
 ) where
 
-import Data.Fix
 import Data.Int
 
 import Test.Tasty
@@ -35,12 +34,13 @@ tests = testGroup "core-lists"
     , testProgram     "Any list"               (progAnyList 2) (PrimBool True)
     , testProgram     "All list"               (progAllList 2) (PrimBool False)
     , testProgram     "All sigma list"         progSigmaAllList
-      (PrimSigma (Fix (SigmaAnd [Fix (SigmaBool True), Fix (SigmaBool False), Fix (SigmaBool True)])))
+      (PrimSigma $ AND () [sigmaB True, sigmaB False, sigmaB True])
     , testProgramFail "Too many reductions"     (progBigListReduce bigSize)
     , testProgram     "Ok amount of reductions" (progBigListReduce okSize) (PrimInt (sum ([0 .. okSize] :: [Int64])))
     ]
   ]
   where
+    sigmaB = Leaf () . Left
     bigSize = 1000000
     okSize  = 1000
 

--- a/hschain-utxo-lang/test/TM/Tx/DTuple.hs
+++ b/hschain-utxo-lang/test/TM/Tx/DTuple.hs
@@ -59,7 +59,7 @@ dtupleTx gx keys = newProofTx (toProofEnv [keys]) $ Tx
     inBox = BoxInputRef
               { boxInputRef'id      = BoxId $ hashBlob "box-1"
               , boxInputRef'args    = mempty
-              , boxInputRef'proof   = Just $ Leaf () $ dtupleInput gx gy gxy
+              , boxInputRef'proof   = Just $ dtupleSigma gx gy gxy
               , boxInputRef'sigs    = []
               , boxInputRef'sigMask = SigAll
               }

--- a/hschain-utxo-lang/test/TM/Tx/DTuple.hs
+++ b/hschain-utxo-lang/test/TM/Tx/DTuple.hs
@@ -7,8 +7,6 @@ module TM.Tx.DTuple(
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.Fix
-
 import HSChain.Crypto (hashBlob)
 import Hschain.Utxo.Lang.Sigma
 import Hschain.Utxo.Lang.Parser.Quoter
@@ -33,7 +31,7 @@ verifyDtupleProof = do
       gy  = getPublicKey bob
       gxy = y .*^ gx
       inp = InputDTuple $ DTuple groupGenerator gx gy gxy
-      expr = Fix $ SigmaPk inp
+      expr = Leaf () inp
   eProof <- newProof (toProofEnv [bob]) expr msg
   return $ either (const False) (\proof -> verifyProof proof msg) eProof
   where
@@ -61,7 +59,7 @@ dtupleTx gx keys = newProofTx (toProofEnv [keys]) $ Tx
     inBox = BoxInputRef
               { boxInputRef'id      = BoxId $ hashBlob "box-1"
               , boxInputRef'args    = mempty
-              , boxInputRef'proof   = Just $ Fix $ SigmaPk $ dtupleInput gx gy gxy
+              , boxInputRef'proof   = Just $ Leaf () $ dtupleInput gx gy gxy
               , boxInputRef'sigs    = []
               , boxInputRef'sigMask = SigAll
               }

--- a/hschain-utxo-lang/test/TM/Tx/Sigma.hs
+++ b/hschain-utxo-lang/test/TM/Tx/Sigma.hs
@@ -19,7 +19,7 @@ tests = testGroup "sigma-protocols"
   ]
 
 -- | Inits transaction that is owned by alice and has correct proof.
-initTx :: IO (Tx, GTx (Sigma ProofInput) Box)
+initTx :: IO (Tx, GTx (SigmaE () ProofInput) Box)
 initTx = do
   aliceSecret <- newSecret
   let alicePubKey = toPublicKey aliceSecret
@@ -29,7 +29,7 @@ initTx = do
   where
     tx pubKey = Tx
       { tx'inputs  = return $ singleOwnerInput (BoxId $ hashBlob "box-1") pubKey
-      , tx'outputs = return $ Box
+       , tx'outputs = return $ Box
           { box'value  = 1
           , box'script = [utxo| pk $(pubKey) |]
           , box'args   = mempty

--- a/hschain-utxo-pow-node/app/CLI.hs
+++ b/hschain-utxo-pow-node/app/CLI.hs
@@ -10,7 +10,6 @@ import Control.Monad
 import Control.Exception
 
 import Data.Int
-import Data.Fix
 import Data.Foldable
 import Data.Text (Text)
 import Data.Map.Strict (Map,(!))
@@ -103,7 +102,7 @@ parseSend = do
                                     ]
           , tx'outputs = V.fromList [
               Box { box'value  = amount
-                  , box'script = coreProgToScript $ EPrim $ PrimSigma $ Fix $ SigmaPk $ dlogInput pk
+                  , box'script = coreProgToScript $ EPrim $ PrimSigma $ sigmaPk $ dlogInput pk
                   , box'args   = mempty
                   }
               ]

--- a/hschain-utxo-pow-node/hschain-utxo-pow-node.cabal
+++ b/hschain-utxo-pow-node/hschain-utxo-pow-node.cabal
@@ -126,7 +126,6 @@ executable hschain-utxo-pow-node-cli
                      , text
                      , yaml
                      , vector
-                     , data-fix                  >=0.3
                      , servant
                      , servant-client
                      , servant-client-core

--- a/hschain-utxo-pow-node/test/TM/BCH/Util.hs
+++ b/hschain-utxo-pow-node/test/TM/BCH/Util.hs
@@ -209,7 +209,7 @@ simpleInputRef :: BoxId -> Sigma.PublicKey -> BoxInputRef (Sigma.SigmaE () Sigma
 simpleInputRef boxId pk = BoxInputRef
   { boxInputRef'id      = boxId
   , boxInputRef'args    = mempty
-  , boxInputRef'proof   = Just $ Sigma.Leaf () $ Sigma.dlogInput pk
+  , boxInputRef'proof   = Just $ Sigma.dlogSigma pk
   , boxInputRef'sigs    = []
   , boxInputRef'sigMask = SigAll
   }

--- a/hschain-utxo-pow-node/test/TM/SmartCon/ErgoMix.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/ErgoMix.hs
@@ -6,7 +6,6 @@ module TM.SmartCon.ErgoMix where
 import Control.Monad.Reader
 
 import Data.ByteString (ByteString)
-import Data.Fix
 import Test.Tasty
 import Test.Tasty.HUnit
 import Prelude hiding ((<*))
@@ -68,13 +67,13 @@ bobJoinMix bobGuess env bob pkAlice bidBob bidAlicePool = do
             , BoxInputRef
                 { boxInputRef'id      = bidAlicePool
                 , boxInputRef'args    = mempty
-                , boxInputRef'proof   = Just $ Fix $ Sigma.SigmaOr
-                                                [ Fix $ Sigma.SigmaOr $ (if bobGuess then id else reverse)
-                                                  [ Sigma.dtupleSigma gx gy gxy
-                                                  , Sigma.dtupleSigma gx gxy gy
-                                                  ]
-                                                , Sigma.dlogSigma gx
-                                                ]
+                , boxInputRef'proof   = Just $ Sigma.OR ()
+                    [ Sigma.OR () $ (if bobGuess then id else reverse)
+                      [ Sigma.dtupleSigma gx gy gxy
+                      , Sigma.dtupleSigma gx gxy gy
+                      ]
+                    , Sigma.dlogSigma gx
+                    ]
                 , boxInputRef'sigs    = []
                 , boxInputRef'sigMask = SigAll
                 }
@@ -113,7 +112,7 @@ aliceSpends bid alice pkBob = do
     spendInput = BoxInputRef
       { boxInputRef'id      = bid
       , boxInputRef'args    = mempty
-      , boxInputRef'proof   = Just $ Fix $ Sigma.SigmaOr
+      , boxInputRef'proof   = Just $ Sigma.OR ()
             [ Sigma.dlogSigma g_xy
             , Sigma.dtupleSigma g_y g_x g_xy
             ]
@@ -137,7 +136,7 @@ bobSpends bid bob pkAlice = do
     spendInput = BoxInputRef
       { boxInputRef'id      = bid
       , boxInputRef'args    = mempty
-      , boxInputRef'proof   = Just $ Fix $ Sigma.SigmaOr
+      , boxInputRef'proof   = Just $ Sigma.OR ()
             [ Sigma.dlogSigma g_y
             , Sigma.dtupleSigma g_xy g_x g_y
             ]

--- a/hschain-utxo-state/src/Hschain/Utxo/State/React.hs
+++ b/hschain-utxo-state/src/Hschain/Utxo/State/React.hs
@@ -56,7 +56,7 @@ updateBoxChain TxArg{..} bch@BoxChain{..}
 -- to get the sigma-expression of the evaluation of the transaction script.
 --
 -- Also it returns debug-log for transaction execution.
-execInBoxChain :: Tx -> BoxChain -> Either Text (Vector BoolExprResult)
+execInBoxChain :: Tx -> BoxChain -> Either Text (Vector ScriptEvalResult)
 execInBoxChain tx bch = do
   txArg <- toTxArg bch tx
   either (Left . renderText) Right $ Core.evalToSigma txArg

--- a/hschain-utxo-test/hschain-utxo-test.cabal
+++ b/hschain-utxo-test/hschain-utxo-test.cabal
@@ -44,7 +44,6 @@ library
                      , hschain-utxo-lang
                      , hschain-utxo-service
                      , hschain-utxo-state
-                     , Boolean
                      , containers
                      , cryptonite
                      , data-fix                  >=0.3

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Monad.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Monad.hs
@@ -182,7 +182,7 @@ getState = call C.getState
 getBoxChainEnv :: App Env
 getBoxChainEnv = fmap unGetEnvResponse $ call C.getEnv
 
-getTxSigma :: Tx -> App (Either Text (Vector (Sigma ProofInput)))
+getTxSigma :: Tx -> App (Either Text (Vector (SigmaE () ProofInput)))
 getTxSigma tx = do
   resp <- call $ C.getTxSigma tx
   logTest $ T.unlines ["PRE TX SIGMA:", showt resp]

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
@@ -76,7 +76,7 @@ getBalance Wallet{..} = do
 -- | Create proof for a most simple expression of @pk user-key@
 getOwnerProof :: MonadIO io => Wallet -> Tx -> io (Either Text Proof)
 getOwnerProof w@Wallet{..} tx =
-  liftIO $ newProof env (Leaf () $ dlogInput (getWalletPublicKey w)) (getSigMessage SigAll tx)
+  liftIO $ newProof env (dlogSigma (getWalletPublicKey w)) (getSigMessage SigAll tx)
   where
     env = toProofEnv [getKeyPair wallet'privateKey]
 


### PR DESCRIPTION
They're almost isomorphic except for a fact that Sigma also allows Boolean literals. Another encoding is to put into leaves `Either Bool ProofInput`. Its advantage is that it allows to separate cases where we can have literal booleans in leaves of a Σ-expression and cases when we have Σ-expression proper. 

It cuts down quite a bit of code. Another possible simplification is to use drop annotation from `SigmaE` and use recursion schemes machinery to annotate constructor during proof construction

