### PR TITLE
Fail if unable to create proof for transaction

### DIFF
--- a/hschain-utxo-lang/test/TM/Tx/DTuple.hs
+++ b/hschain-utxo-lang/test/TM/Tx/DTuple.hs
@@ -45,11 +45,13 @@ verifyDtupleTx = do
 
 
 dtupleTx :: PublicKey -> KeyPair -> IO Tx
-dtupleTx gx keys = newProofTx (toProofEnv [keys]) $ Tx
-  { tx'inputs     = [inBox]
-  , tx'outputs    = [outBox]
-  , tx'dataInputs = []
-  }
+dtupleTx gx keys = do
+  Right tx <- newProofTx (toProofEnv [keys]) $ Tx
+    { tx'inputs     = [inBox]
+    , tx'outputs    = [outBox]
+    , tx'dataInputs = []
+    }
+  pure tx
   where
     gy  = getPublicKey keys
     y   = getSecretKey keys

--- a/hschain-utxo-lang/test/TM/Tx/Sigma.hs
+++ b/hschain-utxo-lang/test/TM/Tx/Sigma.hs
@@ -24,7 +24,7 @@ initTx = do
   aliceSecret <- newSecret
   let alicePubKey = toPublicKey aliceSecret
       aliceProofEnv = toProofEnv [getKeyPair aliceSecret]
-  resTx <- newProofTx aliceProofEnv $ tx alicePubKey
+  Right resTx <- newProofTx aliceProofEnv $ tx alicePubKey
   return (resTx, tx alicePubKey)
   where
     tx pubKey = Tx

--- a/hschain-utxo-pow-node/test/TM/BCH/Util.hs
+++ b/hschain-utxo-pow-node/test/TM/BCH/Util.hs
@@ -132,7 +132,7 @@ badBlock txs = mineBlockE Nothing Nothing txs >>= \case
 
 badTx :: Sigma.ProofEnv -> GTx (Sigma.SigmaE () Sigma.ProofInput) Box -> Mine ()
 badTx env tx = do
-  tx' <- newProofTx env tx
+  Right tx' <- newProofTx env tx
   badBlock [tx']
 
 -- | Same as 'mineBlock' but doesn't throw exception when block is rejected.

--- a/hschain-utxo-pow-node/test/TM/SmartCon/Basic.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/Basic.hs
@@ -36,7 +36,7 @@ noDoubleTx = do
   -- H=1. Alice mines block
   bidAlice <- mineBlock (Just pkAlice) []
   -- H=2. Alice spends mining reward
-  txAlice <- newProofTx sigmaEnv $ Tx
+  Right txAlice <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidAlice pkAlice ]
     , tx'outputs = [ burnBox 100 ]
     , tx'dataInputs = []
@@ -80,7 +80,7 @@ simpleTransfers = do
     , tx'dataInputs = []
     }
   -- Now Alice may spend mined block and pay 10 coin in fees
-  txAlice <- newProofTx sigmaEnv $ Tx
+  Right txAlice <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidAlice pkAlice ]
     , tx'outputs =
       [ Box { box'value  = 60
@@ -99,18 +99,18 @@ simpleTransfers = do
   -- H=3
   --
   --  * Bob burns new coinbase with fee
-  txBob1 <- newProofTx sigmaEnv $ Tx
+  Right txBob1 <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidBob pkBob ]
     , tx'outputs = [ burnBox 110 ]
     , tx'dataInputs = []
     }
   --  * Bob and Charlie burn money received from Alice
-  txBob2 <- newProofTx sigmaEnv $ Tx
+  Right txBob2 <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef (computeBoxId (computeTxId txAlice) 0) pkBob ]
     , tx'outputs = [ burnBox 60 ]
     , tx'dataInputs = []
     }
-  txCharlie <- newProofTx sigmaEnv $ Tx
+  Right txCharlie <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef (computeBoxId (computeTxId txAlice) 1) pkCharlie ]
     , tx'outputs = [ burnBox 30 ]
     , tx'dataInputs = []

--- a/hschain-utxo-pow-node/test/TM/SmartCon/ErgoMix.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/ErgoMix.hs
@@ -45,7 +45,7 @@ ergoMixTest = do
 
 alicePostToPool :: ProofEnv -> PublicKey -> BoxId -> Mine BoxId
 alicePostToPool env pkAlice bidAlice = do
-  tx <- newProofTx env $ Tx
+  Right tx <- newProofTx env $ Tx
         { tx'inputs  = [ singleOwnerInput bidAlice pkAlice ]
         , tx'outputs =
             [ Box { box'value  = 100
@@ -60,7 +60,7 @@ alicePostToPool env pkAlice bidAlice = do
 
 bobJoinMix :: Bool -> ProofEnv -> KeyPair -> PublicKey -> BoxId -> BoxId -> Mine (BoxId, BoxId)
 bobJoinMix bobGuess env bob pkAlice bidBob bidAlicePool = do
-  tx <- newProofTx env $ Tx
+  Right tx <- newProofTx env $ Tx
         { tx'inputs =
             [ singleOwnerInput bidBob pkBob
             , BoxInputRef
@@ -101,7 +101,7 @@ bobJoinMix bobGuess env bob pkAlice bidBob bidAlicePool = do
 
 aliceSpends :: BoxId -> KeyPair -> PublicKey -> Mine ()
 aliceSpends bid alice pkBob = do
-  tx <- newProofTx (toProofEnv [alice]) $ Tx
+  Right tx <- newProofTx (toProofEnv [alice]) $ Tx
         { tx'inputs  = [spendInput ]
         , tx'outputs = [ burnBox 100 ]
         , tx'dataInputs = []
@@ -125,7 +125,7 @@ aliceSpends bid alice pkBob = do
 
 bobSpends :: BoxId -> KeyPair -> PublicKey -> Mine ()
 bobSpends bid bob pkAlice = do
-  tx <- newProofTx (toProofEnv [bob]) $ Tx
+  Right tx <- newProofTx (toProofEnv [bob]) $ Tx
         { tx'inputs  = [spendInput ]
         , tx'outputs = [ burnBox 100 ]
         , tx'dataInputs = []

--- a/hschain-utxo-pow-node/test/TM/SmartCon/PayForCoffee.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/PayForCoffee.hs
@@ -32,7 +32,7 @@ payforCoffee isBob = do
   -- H=1 Alice mines block
   bidAlice <- mineBlock (Just pkAlice) []
   -- H=2 Alice sends reward to Bob with time-lock
-  txToBob <- newProofTx sigmaEnv $ Tx
+  Right txToBob <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidAlice pkAlice ]
     , tx'outputs =
       [ Box { box'value  = 100
@@ -48,7 +48,7 @@ payforCoffee isBob = do
   case isBob of
     True -> do
       -- H=3 Bob tries to spend transaction
-      txBob <- newProofTx sigmaEnv $ Tx
+      Right txBob <- newProofTx sigmaEnv $ Tx
         { tx'inputs  = [ simpleInputRef coffeeBoxId pkBob ]
         , tx'outputs = [ burnBox 100 ]
         , tx'dataInputs = []
@@ -63,7 +63,7 @@ payforCoffee isBob = do
     ----------------------------------------
     False -> do
       -- H=3 Alice tries to spend transaction
-      txAlice <- newProofTx sigmaEnv $ Tx
+      Right txAlice <- newProofTx sigmaEnv $ Tx
         { tx'inputs  = [ simpleInputRef coffeeBoxId pkAlice ]
         , tx'outputs = [ burnBox 100 ]
         , tx'dataInputs = []

--- a/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
+++ b/hschain-utxo-pow-node/test/TM/SmartCon/XorGame.hs
@@ -44,8 +44,8 @@ xorGame aliceGuess bobGuess = do
   (commitmentHash, secret) <- makeAliceSecret aliceGuess
   let fullScript = fullGameScript commitmentHash (encodeToBS pkAlice)
       halfScript = halfGameScript $ hashScript fullScript
-  -- Alice posts half-game transaction
-  txAlice <- newProofTx sigmaEnv $ Tx
+  -- Right Alice posts half-game transaction
+  Right txAlice <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidAlice pkAlice ]
     , tx'outputs = [
         Box { box'value  = 100
@@ -58,7 +58,7 @@ xorGame aliceGuess bobGuess = do
   let aliceGameBid = computeBoxId (computeTxId txAlice) 0
   _ <- mineBlock Nothing [ txAlice ]
   -- Bob posts full game script
-  txBob <- newProofTx sigmaEnv $ Tx
+  Right txBob <- newProofTx sigmaEnv $ Tx
     { tx'inputs  = [ simpleInputRef bidBob pkBob
                    , BoxInputRef { boxInputRef'id      = aliceGameBid
                                  , boxInputRef'args    = mempty
@@ -105,13 +105,13 @@ xorGame aliceGuess bobGuess = do
     -- Alice wins
     True -> do
       badTx sigmaEnv bobWin
-      tx <- newProofTx sigmaEnv aliceWin
+      Right tx <- newProofTx sigmaEnv aliceWin
       _  <- mineBlock Nothing [tx]
       pure ()
     -- Bob wins
     False -> do
       badTx sigmaEnv aliceWin
-      tx <- newProofTx sigmaEnv bobWin
+      Right tx <- newProofTx sigmaEnv bobWin
       _  <- mineBlock Nothing [tx]
       pure ()
 

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/AtomicSwap.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/AtomicSwap.hs
@@ -134,7 +134,8 @@ aliceInitSwapScript spec = [utxo|
 aliceInitSwapTx :: ProofEnv -> BoxId -> SwapSpec -> App Tx
 aliceInitSwapTx aliceKeys inputId spec = do
   Just totalValue <- getBoxBalance inputId
-  newProofTx aliceKeys $ preTx totalValue
+  Right tx <- newProofTx aliceKeys $ preTx totalValue
+  pure tx
   where
     swapHash = swapSpec'hash spec
 
@@ -158,7 +159,9 @@ aliceInitSwapTx aliceKeys inputId spec = do
 -- | Alice grabs the Bob's funds and reveals the secret.
 -- She can not double spend her funds because of deadline of the script for her returns.
 aliceGrabTx :: ProofEnv -> BoxId -> SwapSpec -> App Tx
-aliceGrabTx aliceKeys inputId spec = newProofTx aliceKeys preTx
+aliceGrabTx aliceKeys inputId spec = do
+  Right tx <- newProofTx aliceKeys preTx
+  pure tx
   where
     preTx = Tx
       { tx'inputs     = pure $ addSecret $ singleOwnerInput inputId alicePubKey
@@ -175,7 +178,9 @@ aliceGrabTx aliceKeys inputId spec = newProofTx aliceKeys preTx
 
 -- | Attempt to doublespend (It should fail).
 aliceDoubleSpendTx :: ProofEnv -> BoxId -> SwapSpec -> App Tx
-aliceDoubleSpendTx aliceKeys inputId spec = newProofTx aliceKeys preTx
+aliceDoubleSpendTx aliceKeys inputId spec = do
+  Right tx <- newProofTx aliceKeys preTx
+  pure tx
   where
     preTx = Tx
       { tx'inputs     = [ singleOwnerInput inputId alicePubKey ]
@@ -211,7 +216,8 @@ bobInitSwapScript swapHash spec = [utxo|
 bobInitSwapTx :: ProofEnv -> SwapHash -> BoxId -> SwapSpec -> App Tx
 bobInitSwapTx bobKeys swapHash inputId spec = do
   Just totalValue <- getBoxBalance inputId
-  newProofTx bobKeys $ preTx totalValue
+  Right tx <- newProofTx bobKeys $ preTx totalValue
+  pure tx
   where
     preTx totalValue = Tx
       { tx'inputs     = [ singleOwnerInput inputId bobPubKey ]
@@ -231,7 +237,9 @@ bobInitSwapTx bobKeys swapHash inputId spec = do
       }
 
 bobGrabTx :: ProofEnv -> SwapSecret -> BoxId -> SwapSpec -> App Tx
-bobGrabTx bobKeys aliceSecret inputId spec = newProofTx bobKeys preTx
+bobGrabTx bobKeys aliceSecret inputId spec = do
+  Right tx <- newProofTx bobKeys preTx
+  pure tx
   where
     preTx = Tx
       { tx'inputs     = [addSecret $ singleOwnerInput inputId bobPubKey]

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Channel.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Channel.hs
@@ -447,8 +447,9 @@ offChainPreTx revoceSecret commonBoxId (myValue, partnerValue) myPk partnerPk = 
       }
 
 getRevoceTx :: Wallet -> RevoceBox -> App (Tx, BoxId)
-getRevoceTx wallet RevoceBox{..} =
-  fmap appendBoxId $ newProofTx (getProofEnv wallet) preTx
+getRevoceTx wallet RevoceBox{..} = do
+  Right tx <- newProofTx (getProofEnv wallet) preTx
+  pure $ appendBoxId tx 
   where
     appendBoxId tx@Tx{..} = (tx, computeBoxId (computeTxId tx) 0)
 

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Lightning/Tx.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/Lightning/Tx.hs
@@ -22,11 +22,13 @@ type Balance = (Money, Money)
 
 -- | Funding TX
 fundingTx :: MonadIO io => Wallet -> (Money, Money) -> [BoxId] -> PublicKey -> io Tx
-fundingTx wallet (value, change) inputIds otherPubKey = newProofTx  (getProofEnv wallet) $ Tx
-  { tx'inputs     = V.fromList $ fmap (singleOwnerBoxRef wallet) inputIds
-  , tx'outputs    = V.fromList $ catMaybes [Just fundBox, changeBox]
-  , tx'dataInputs = []
-  }
+fundingTx wallet (value, change) inputIds otherPubKey = liftIO $ do
+  Right tx <- newProofTx  (getProofEnv wallet) $ Tx
+    { tx'inputs     = V.fromList $ fmap (singleOwnerBoxRef wallet) inputIds
+    , tx'outputs    = V.fromList $ catMaybes [Just fundBox, changeBox]
+    , tx'dataInputs = []
+    }
+  pure tx
   where
     fundBox = Box
       { box'value  = value

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/MultiSig.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Scripts/MultiSig.hs
@@ -154,7 +154,7 @@ simpleSpendTo isSuccess message wallet fromId toPubKey value = do
 
 simpleSpendToTx :: Wallet -> BoxId -> PublicKey -> Int64 -> App (Either Text Tx)
 simpleSpendToTx wallet fromId toPubKey value =
-  newProofTxOrFail (getProofEnv wallet) preTx
+  newProofTx (getProofEnv wallet) preTx
   where
     preTx = Tx
       { tx'inputs     = [inputRef]

--- a/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
+++ b/hschain-utxo-test/src/Hschain/Utxo/Test/Client/Wallet.hs
@@ -129,7 +129,7 @@ singleOwnerSigmaExpr wallet = Leaf () $ dlogInput $ getWalletPublicKey wallet
 -- returns tripple: (tx, box address for change if needed, receiver output result)
 toSendTx :: Wallet -> Send -> SendBack -> App (Either Text (Tx, Maybe BoxId, BoxId))
 toSendTx wallet Send{..} SendBack{..} =
-  fmap (fmap appendSenderReceiverIds) $ newProofTxOrFail (getProofEnv wallet) preTx
+  fmap (fmap appendSenderReceiverIds) $ newProofTx (getProofEnv wallet) preTx
   where
     preTx = Tx
       { tx'inputs     = V.fromList [inputBox]


### PR DESCRIPTION
Replace newTxProof with newTxProofOrFail. We'll need proper support for assembling transactions eventually. But putting `Nothing` instead of proof it's not possible to create one is not really useful